### PR TITLE
Parametrized instance creation for android web driver - it's needed, because the default value of the remoteAddress parameter is set to 'http://localhost:8080/...', so there can be a contflict with some web services.

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.drone.spi.DroneConfiguration;
  * properties.
  *
  * @author <a href="kpiwko@redhat.com>Karel Piwko</a>
+ * @author <a href="jpapouse@redhat.com>Jan Papousek</a>
  * @see ArquillianDescriptor
  * @see org.jboss.arquillian.drone.configuration.ConfigurationMapper
  *
@@ -35,6 +36,7 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
     public static final String CONFIGURATION_NAME = "webdriver";
 
     private String implementationClass = "org.openqa.selenium.htmlunit.HtmlUnitDriver";
+    private String androidRemoteAddress = "http://localhost:8080/wd/hub";
 
     /**
      * Creates default Selenium WebDriver Configuration
@@ -70,10 +72,24 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
     }
 
     /**
+     * @return the remote address used for testing via android sdk
+     */
+    public String getAndroidRemoteAddress() {
+        return androidRemoteAddress;
+    }
+
+    /**
      * @param implementationClass the implementationClass to set
      */
     public void setImplementationClass(String implementationClass) {
         this.implementationClass = implementationClass;
+    }
+
+    /**
+     * @param remoteAddress the remote address used for testing via android sdk
+     */
+    public void setAndroidRemoteAddress(String androidRemoteAddress) {
+        this.androidRemoteAddress = androidRemoteAddress;
     }
 
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/WebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/WebDriverFactory.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.WebDriver;
  * WebDriver browser object called {@link org.openqa.selenium.WebDriver}.
  *
  * @author <a href="kpiwko@redhat.com>Karel Piwko</a>
+ * @author <a href="jpapouse@redhat.com>Jan Papousek</a>
  *
  */
 public class WebDriverFactory implements Configurator<WebDriver, WebDriverConfiguration>,
@@ -60,9 +61,12 @@ public class WebDriverFactory implements Configurator<WebDriver, WebDriverConfig
      * @see org.jboss.arquillian.drone.spi.Instantiator#createInstance(org.jboss.arquillian.drone.spi.DroneConfiguration)
      */
     public WebDriver createInstance(WebDriverConfiguration configuration) {
-        WebDriver driver = SecurityActions.newInstance(configuration.getImplementationClass(), new Class<?>[0], new Object[0],
-                WebDriver.class);
-        return driver;
+        if ("org.openqa.selenium.android.AndroidDriver".equals(configuration.getImplementationClass())) {
+            return createInstanceAndroid(configuration);
+        }
+        else {
+            return createInstanceDefault(configuration);
+        }
     }
 
     /*
@@ -76,4 +80,31 @@ public class WebDriverFactory implements Configurator<WebDriver, WebDriverConfig
         return new WebDriverConfiguration().configure(descriptor, qualifier);
     }
 
+    /**
+     * Creates a new instance of android web driver with parameters from the given configuration
+     * 
+     * @param configuration 
+     * @return a new instance of android web driver
+     */
+    private WebDriver createInstanceAndroid(WebDriverConfiguration configuration) {
+        return SecurityActions.newInstance(
+            configuration.getImplementationClass(),
+            new Class<?>[] {String.class},
+            new Object[] {configuration.getAndroidRemoteAddress()},
+            WebDriver.class);
+    }
+
+    /**
+     * Creates a new instance of web driver without any paramaters
+     * 
+     * @param configuration 
+     * @return a new instance of web driver
+     */
+    private WebDriver createInstanceDefault(WebDriverConfiguration configuration) {
+        return SecurityActions.newInstance(
+            configuration.getImplementationClass(),
+            new Class<?>[0],
+            new Object[0],
+            WebDriver.class);
+    }
 }


### PR DESCRIPTION
added configuration option 'androidRemoteAddress' for android web drivers
