### PR TITLE
ARQ-1537 Support for Safari browser

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/DroneWebDriverExtension.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/DroneWebDriverExtension.java
@@ -32,6 +32,7 @@ import org.jboss.arquillian.drone.webdriver.factory.InternetExplorerDriverFactor
 import org.jboss.arquillian.drone.webdriver.factory.OperaDriverFactory;
 import org.jboss.arquillian.drone.webdriver.factory.PhantomJSDriverFactory;
 import org.jboss.arquillian.drone.webdriver.factory.RemoteWebDriverFactory;
+import org.jboss.arquillian.drone.webdriver.factory.SafariDriverFactory;
 import org.jboss.arquillian.drone.webdriver.factory.WebDriverFactory;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusableRemoteWebDriverExtension;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusedSessionPernamentFileStorage;
@@ -85,6 +86,10 @@ public class DroneWebDriverExtension implements LoadableExtension {
         builder.service(Instantiator.class, RemoteWebDriverFactory.class);
         builder.service(Destructor.class, RemoteWebDriverFactory.class);
 
+        builder.service(Configurator.class, SafariDriverFactory.class);
+        builder.service(Instantiator.class, SafariDriverFactory.class);
+        builder.service(Destructor.class, SafariDriverFactory.class);
+
         builder.service(Configurator.class, PhantomJSDriverFactory.class);
         builder.service(Instantiator.class, PhantomJSDriverFactory.class);
         builder.service(Destructor.class, PhantomJSDriverFactory.class);
@@ -99,6 +104,7 @@ public class DroneWebDriverExtension implements LoadableExtension {
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.IPhone.class);
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.Opera.class);
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.Remote.class);
+        builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.Safari.class);
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.PhantomJS.class);
 
         builder.observer(ReusableRemoteWebDriverExtension.class);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
@@ -200,6 +200,30 @@ public class BrowserCapabilitiesList {
 
     };
 
+    public static class Safari implements BrowserCapabilities {
+
+        @Override
+        public String getReadableName() {
+            return "safari";
+        }
+
+        @Override
+        public String getImplementationClassName() {
+            return "org.openqa.selenium.safari.SafariDriver";
+        }
+
+        @Override
+        public Map<String, ?> getRawCapabilities() {
+            return DesiredCapabilities.safari().asMap();
+        }
+
+        @Override
+        public int getPrecedence() {
+            return 0;
+        }
+
+    };
+
     public static class PhantomJS implements BrowserCapabilities {
 
         @Override

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/SafariDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/SafariDriverFactory.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import org.jboss.arquillian.drone.spi.Configurator;
+import org.jboss.arquillian.drone.spi.Destructor;
+import org.jboss.arquillian.drone.spi.Instantiator;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.safari.SafariDriver;
+
+/**
+ * Factory which combines {@link org.jboss.arquillian.drone.spi.Configurator},
+ * {@link org.jboss.arquillian.drone.spi.Instantiator} and {@link org.jboss.arquillian.drone.spi.Destructor} for SafariDriver.
+ *
+ * @author <a href="jlocker@redhat.com>Jiri Locker</a>
+ *
+ */
+public class SafariDriverFactory extends AbstractWebDriverFactory<SafariDriver> implements
+        Configurator<SafariDriver, WebDriverConfiguration>, Instantiator<SafariDriver, WebDriverConfiguration>,
+        Destructor<SafariDriver> {
+
+    private static final String BROWSER_CAPABILITIES = new BrowserCapabilitiesList.Safari().getReadableName();
+
+    @Override
+    public int getPrecedence() {
+        return 0;
+    }
+
+    @Override
+    public void destroyInstance(SafariDriver instance) {
+        instance.quit();
+    }
+
+    @Override
+    public SafariDriver createInstance(WebDriverConfiguration configuration) {
+
+        DesiredCapabilities capabilities = new DesiredCapabilities(configuration.getCapabilities());
+
+        return SecurityActions.newInstance(configuration.getImplementationClass(), new Class<?>[] { Capabilities.class },
+                new Object[] { capabilities }, SafariDriver.class);
+
+    }
+
+    @Override
+    protected String getDriverReadableName() {
+        return BROWSER_CAPABILITIES;
+    }
+
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/example/SafariDriverTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/example/SafariDriverTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver.example;
+
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.safari.SafariDriver;
+
+/**
+ * Tests Arquillian Selenium extension against Weld Login example.
+ *
+ * This test is currently ignored because SafariDriver cannot access {@literal file://} URLs
+ * (<a href="http://code.google.com/p/selenium/issues/detail?id=3773">Issue 3773</a>).
+ *
+ * @author <a href="mailto:jlocker@redhat.com">Jiri Locker</a>
+ *
+ * @see org.jboss.arquillian.drone.webdriver.factory.WebDriverFactory
+ */
+@RunWith(Arquillian.class)
+@Ignore
+public class SafariDriverTestCase extends AbstractWebDriver {
+
+    @Drone
+    SafariDriver driver;
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.arquillian.drone.webdriver.example.AbstractWebDriverTestCase#driver()
+     */
+    @Override
+    protected WebDriver driver() {
+        return driver;
+    }
+
+}


### PR DESCRIPTION
Basic implementation of Safari BrowserCapabilities.

Works with Safari 5.1.3, System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.7.3', java.version: '1.6.0_31'.

SafariDriverTestCase is ignored because SafariDriver cannot access URLs with file: protocol (http://code.google.com/p/selenium/issues/detail?id=3773).
