### PR TITLE
ARQ-1692 Factories are registered based on WebDriver's presence on class path

### DIFF
--- a/drone-webdriver/pom.xml
+++ b/drone-webdriver/pom.xml
@@ -189,6 +189,17 @@
                 </property>
             </activation>
 
+            <properties>
+                <selenium.chrome.driver>org.seleniumhq.selenium:selenium-chrome-driver:jar</selenium.chrome.driver>
+                <selenium.firefox.driver>org.seleniumhq.selenium:selenium-firefox-driver</selenium.firefox.driver>
+                <selenium.htmlunit.driver>org.seleniumhq.selenium:selenium-htmlunit-driver:jar
+                </selenium.htmlunit.driver>
+                <selenium.ie.driver>org.seleniumhq.selenium:selenium-ie-driver:jar</selenium.ie.driver>
+                <selenium.safari.driver>org.seleniumhq.selenium:selenium-safari-driver:jar</selenium.safari.driver>
+                <codeborne.phantomjs.driver>com.codeborne:phantomjsdriver:jar</codeborne.phantomjs.driver>
+                <opera.opera.driver>com.opera:operadriver</opera.opera.driver>
+            </properties>
+
             <dependencies>
                 <!-- Container -->
                 <dependency>
@@ -249,6 +260,44 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>false</skipTests>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>register-webdriverfactory-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>
+                                            **/WebDriverFactoryRegisterTestCase.java
+                                        </include>
+                                    </includes>
+                                    <classpathDependencyExcludes>
+                                        <dependencyExclude>${selenium.chrome.driver}</dependencyExclude>
+                                        <dependencyExclude>${selenium.firefox.driver}</dependencyExclude>
+                                        <dependencyExclude>${selenium.htmlunit.driver}</dependencyExclude>
+                                        <dependencyExclude>${selenium.ie.driver}</dependencyExclude>
+                                        <dependencyExclude>${selenium.safari.driver}</dependencyExclude>
+                                        <dependencyExclude>${codeborne.phantomjs.driver}</dependencyExclude>
+                                        <dependencyExclude>${opera.opera.driver}</dependencyExclude>
+                                    </classpathDependencyExcludes>
+                                    <skipTests>false</skipTests>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -265,6 +314,7 @@
 
             <properties>
                 <browser>firefox</browser>
+                <selenium.firefox.driver>dummy</selenium.firefox.driver>
             </properties>
         </profile>
         <profile>
@@ -279,6 +329,52 @@
 
             <properties>
                 <browser>chrome</browser>
+                <selenium.chrome.driver>dummy</selenium.chrome.driver>
+            </properties>
+        </profile>
+        <profile>
+            <id>htmlunit</id>
+
+            <activation>
+                <property>
+                    <name>browser</name>
+                    <value>htmlunit</value>
+                </property>
+            </activation>
+
+            <properties>
+                <browser>htmlunit</browser>
+                <selenium.htmlunit.driver>dummy</selenium.htmlunit.driver>
+            </properties>
+        </profile>
+        <profile>
+            <id>safari</id>
+
+            <activation>
+                <property>
+                    <name>browser</name>
+                    <value>safari</value>
+                </property>
+            </activation>
+
+            <properties>
+                <browser>safari</browser>
+                <selenium.safari.driver>dummy</selenium.safari.driver>
+            </properties>
+        </profile>
+        <profile>
+            <id>ie</id>
+
+            <activation>
+                <property>
+                    <name>browser</name>
+                    <value>ie</value>
+                </property>
+            </activation>
+
+            <properties>
+                <browser>ie</browser>
+                <selenium.ie.driver>dummy</selenium.ie.driver>
             </properties>
         </profile>
         <profile>
@@ -293,6 +389,22 @@
 
             <properties>
                 <browser>phantomjs</browser>
+                <codeborne.phantomjs.driver>dummy</codeborne.phantomjs.driver>
+            </properties>
+        </profile>
+        <profile>
+            <id>opera</id>
+
+            <activation>
+                <property>
+                    <name>browser</name>
+                    <value>opera</value>
+                </property>
+            </activation>
+
+            <properties>
+                <browser>opera</browser>
+                <opera.opera.driver>dummy</opera.opera.driver>
             </properties>
         </profile>
     </profiles>

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/DroneWebDriverExtension.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/DroneWebDriverExtension.java
@@ -94,7 +94,7 @@ public class DroneWebDriverExtension implements LoadableExtension {
     }
 
     private <T extends Configurator & Instantiator & Destructor> void registerFactoryService(
-        ExtensionBuilder builder, Class<? extends T> factory, String expectedDriver) {
+        ExtensionBuilder builder, Class<T> factory, String expectedDriver) {
 
         try {
             Class.forName(expectedDriver, false, this.getClass().getClassLoader());

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Constants.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Constants.java
@@ -1,0 +1,37 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver.utils;
+
+/**
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class Constants {
+
+    public static final String WEB_DRIVER_NOT_FOUND_ERROR_MESSAGE =
+        "The required web driver class {0} is not on your class path so the factory {1} will not be available.";
+
+    public static final String FIREFOX_DRIVER = "org.openqa.selenium.firefox.FirefoxDriver";
+    public static final String CHROME_DRIVER = "org.openqa.selenium.chrome.ChromeDriver";
+    public static final String HTMLUNIT_DRIVER = "org.openqa.selenium.htmlunit.HtmlUnitDriver";
+    public static final String IE_DRIVER = "org.openqa.selenium.ie.InternetExplorerDriver";
+    public static final String WEB_DRIVER = "org.openqa.selenium.WebDriver";
+    public static final String OPERA_DRIVER = "com.opera.core.systems.OperaDriver";
+    public static final String REMOTE_DRIVER = "org.openqa.selenium.remote.RemoteWebDriver";
+    public static final String SAFARI_DRIVER = "org.openqa.selenium.safari.SafariDriver";
+    public static final String PHANTOMJS_DRIVER = "org.openqa.selenium.phantomjs.PhantomJSDriver";
+
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/register/WebDriverFactoryRegisterTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/register/WebDriverFactoryRegisterTestCase.java
@@ -1,0 +1,25 @@
+package org.jboss.arquillian.drone.webdriver.register;
+
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+@RunWith(Arquillian.class)
+public class WebDriverFactoryRegisterTestCase {
+
+    @Drone
+    private WebDriver browser;
+
+    @Test
+    public void verifyDrone() {
+        assertNotNull(browser);
+    }
+}


### PR DESCRIPTION
It is not very nice solution, but probably the only one without modifying arquillian-core behaviour (specifically this https://github.com/arquillian/arquillian-core/blob/master/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoader.java#L103-L108)
 
It basically check whether the required WebDriver of some particular factory is on class path. If not, the warning is printed and the factory is not registered.