### PR TITLE
#71: Adds command line arguments for selenium server.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -334,7 +334,14 @@ your changes there first.
 
 Prerequisites:
 
-* running Selenium Server at port 4444, with paths to binaries required for remote browser execution. If you don't do it by yourself, Drone will run an instance of Selenium Server automatically. However in this case the server is started and stopped for each test class separately and only in a standalone mode. So, if you are fine with this automatic behavior you can skip this step, otherwise run your Selenium Server.
+* running Selenium Server at port 4444, with paths to binaries required for remote browser execution. If you don't do it by yourself, Drone will run an instance of Selenium Server automatically. However in this case the server is started and stopped for each test class separately and only in a standalone mode with only one parameter `-port` that is taken from defined remoteAddress.
++
+In case you want to specify other arguments to the selenium server, you can do so using the property,
++
+`<property name="seleniumServerArgs">-debug -role hub -browserTimeout 1000</property>`
++
+So, if you are fine with this automatic behavior you can skip this step, otherwise run your Selenium Server.
+
 * installed web browsers you want to test
 * you might want to align your layout to be the same as paths to binaries specified within arquillian.xml in _drone-webdriver_ module. Alternatively, you can override properties with 
  +-Darq.extension.${extensionQualifier}.${propertyName}+

--- a/drone-configuration/src/test/java/org/jboss/arquillian/drone/configuration/MockDroneConfiguration.java
+++ b/drone-configuration/src/test/java/org/jboss/arquillian/drone/configuration/MockDroneConfiguration.java
@@ -155,8 +155,12 @@ public class MockDroneConfiguration implements DroneConfiguration<MockDroneConfi
         this.browserCapabilities = browserCapabilities;
     }
 
-    public String getSeleniumServerArgs() { return seleniumServerArgs; }
+    public String getSeleniumServerArgs() {
+        return seleniumServerArgs;
+    }
 
-    public void setSeleniumServerArgs(String seleniumServerArgs) { this.seleniumServerArgs = seleniumServerArgs; }
+    public void setSeleniumServerArgs(String seleniumServerArgs) {
+        this.seleniumServerArgs = seleniumServerArgs;
+    }
 
 }

--- a/drone-configuration/src/test/java/org/jboss/arquillian/drone/configuration/MockDroneConfiguration.java
+++ b/drone-configuration/src/test/java/org/jboss/arquillian/drone/configuration/MockDroneConfiguration.java
@@ -52,6 +52,8 @@ public class MockDroneConfiguration implements DroneConfiguration<MockDroneConfi
 
     private String browserCapabilities;
 
+    private String seleniumServerArgs;
+
     /*
      * (non-Javadoc)
      *
@@ -152,5 +154,9 @@ public class MockDroneConfiguration implements DroneConfiguration<MockDroneConfi
     public void setBrowserCapabilities(String browserCapabilities) {
         this.browserCapabilities = browserCapabilities;
     }
+
+    public String getSeleniumServerArgs() { return seleniumServerArgs; }
+
+    public void setSeleniumServerArgs(String seleniumServerArgs) { this.seleniumServerArgs = seleniumServerArgs; }
 
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
@@ -43,10 +43,12 @@ public class SeleniumServerExecutor {
      */
     public void startSeleniumServer(@Observes StartSeleniumServer startSeleniumServer) {
         String browser = startSeleniumServer.getBrowser();
+        String seleniumServerArgs = startSeleniumServer.getSeleniumServerArgs();
         String seleniumServer = startSeleniumServer.getPathToSeleniumServerBinary();
         int port = startSeleniumServer.getUrl().getPort();
 
         BinaryHandler browserBinaryHandler = getBrowserBinaryHandler(startSeleniumServer.getCapabilities(), browser);
+
 
         CommandBuilder javaCommand = new CommandBuilder("java");
         if (browserBinaryHandler != null) {
@@ -67,7 +69,8 @@ public class SeleniumServerExecutor {
         }
 
         try {
-            Command build = javaCommand.parameters("-jar", seleniumServer, "-port", String.valueOf(port)).build();
+            Command build = javaCommand.parameters("-jar", seleniumServer, "-port", String.valueOf(port), seleniumServerArgs).build();
+
             SeleniumServerExecution execution = new SeleniumServerExecution().execute(build);
             seleniumServerExecutionInstanceProducer.set(execution);
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
@@ -1,6 +1,9 @@
 package org.jboss.arquillian.drone.webdriver.binary.process;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -49,7 +52,6 @@ public class SeleniumServerExecutor {
 
         BinaryHandler browserBinaryHandler = getBrowserBinaryHandler(startSeleniumServer.getCapabilities(), browser);
 
-
         CommandBuilder javaCommand = new CommandBuilder("java");
         if (browserBinaryHandler != null) {
             try {
@@ -69,7 +71,12 @@ public class SeleniumServerExecutor {
         }
 
         try {
-            Command build = javaCommand.parameters("-jar", seleniumServer, "-port", String.valueOf(port), seleniumServerArgs).build();
+            List<String> parameterList = new ArrayList<>(Arrays.asList("-jar", seleniumServer, "-port", String.valueOf(port)));
+
+            if (seleniumServerArgs != null && !seleniumServerArgs.isEmpty()){
+                parameterList.add(seleniumServerArgs);
+            }
+            Command build = javaCommand.parameters(parameterList).build();
 
             SeleniumServerExecution execution = new SeleniumServerExecution().execute(build);
             seleniumServerExecutionInstanceProducer.set(execution);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
@@ -74,11 +74,13 @@ public class SeleniumServerExecutor {
             List<String> parameterList = new ArrayList<>(Arrays.asList("-jar", seleniumServer, "-port", String.valueOf(port)));
 
             if (seleniumServerArgs != null && !seleniumServerArgs.isEmpty()){
-                parameterList.add(seleniumServerArgs);
+                parameterList.addAll(Arrays.asList(seleniumServerArgs.split(" ")));
             }
+
             Command build = javaCommand.parameters(parameterList).build();
 
             SeleniumServerExecution execution = new SeleniumServerExecution().execute(build);
+
             seleniumServerExecutionInstanceProducer.set(execution);
 
         } catch (Exception e) {

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/StartSeleniumServer.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/StartSeleniumServer.java
@@ -14,13 +14,15 @@ public class StartSeleniumServer implements Event {
     private String browser;
     private DesiredCapabilities capabilities;
     private URL url;
+    private String seleniumServerArgs;
 
     public StartSeleniumServer(String pathToSeleniumServerBinary, String browser,
-        DesiredCapabilities capabilities, URL url) {
+        DesiredCapabilities capabilities, URL url, String seleniumServerArgs) {
         this.pathToSeleniumServerBinary = pathToSeleniumServerBinary;
         this.browser = browser;
         this.capabilities = capabilities;
         this.url = url;
+        this.seleniumServerArgs = seleniumServerArgs;
     }
 
     public String getPathToSeleniumServerBinary() {
@@ -30,6 +32,10 @@ public class StartSeleniumServer implements Event {
     public void setPathToSeleniumServerBinary(String pathToSeleniumServerBinary) {
         this.pathToSeleniumServerBinary = pathToSeleniumServerBinary;
     }
+
+    public String getSeleniumServerArgs() { return seleniumServerArgs; }
+
+    public void setSeleniumServerArgs(String seleniumServerArgs) { this.seleniumServerArgs = seleniumServerArgs; }
 
     public String getBrowser() {
         return browser;

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/StartSeleniumServer.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/StartSeleniumServer.java
@@ -33,9 +33,13 @@ public class StartSeleniumServer implements Event {
         this.pathToSeleniumServerBinary = pathToSeleniumServerBinary;
     }
 
-    public String getSeleniumServerArgs() { return seleniumServerArgs; }
+    public String getSeleniumServerArgs() {
+        return seleniumServerArgs;
+    }
 
-    public void setSeleniumServerArgs(String seleniumServerArgs) { this.seleniumServerArgs = seleniumServerArgs; }
+    public void setSeleniumServerArgs(String seleniumServerArgs) {
+        this.seleniumServerArgs = seleniumServerArgs;
+    }
 
     public String getBrowser() {
         return browser;

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
@@ -55,7 +55,7 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
 
     public static final String DEFAULT_BROWSER_CAPABILITIES = new BrowserCapabilitiesList.HtmlUnit().getReadableName();
 
-    public static final String DEFAULT_SELENIUM_SERVER_ARGS = null;
+    public static final String DEFAULT_SELENIUM_SERVER_ARGS = "";
 
     private int iePort;
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
@@ -16,14 +16,6 @@
  */
 package org.jboss.arquillian.drone.webdriver.configuration;
 
-import java.lang.annotation.Annotation;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.drone.configuration.ConfigurationMapper;
 import org.jboss.arquillian.drone.spi.DroneConfiguration;
@@ -31,6 +23,14 @@ import org.jboss.arquillian.drone.webdriver.factory.BrowserCapabilitiesList;
 import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Generic configuration for WebDriver Driver. By default, it uses HtmlUnit Driver.
@@ -55,6 +55,8 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
 
     public static final String DEFAULT_BROWSER_CAPABILITIES = new BrowserCapabilitiesList.HtmlUnit().getReadableName();
 
+    public static final String DEFAULT_SELENIUM_SERVER_ARGS = null;
+
     private int iePort;
 
     private URL remoteAddress;
@@ -64,6 +66,8 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
     private boolean remoteReusable;
 
     private boolean remote;
+
+    private String seleniumServerArgs;
 
     // ARQ-1206, ability to delete all cookies in reused browsers
     private boolean reuseCookies;
@@ -126,6 +130,10 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
             new DesiredCapabilities(this.capabilityMap));
     }
 
+    public String getSeleniumServerArgs() {
+        return seleniumServerArgs;
+    }
+
     @Override
     public String getConfigurationName() {
         return CONFIGURATION_NAME;
@@ -185,5 +193,9 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
 
     public void setDimensions(String dimensions) {
         this.dimensions = dimensions;
+    }
+
+    public void setSeleniumServerArgs(String seleniumServerArgs) {
+        this.seleniumServerArgs = seleniumServerArgs;
     }
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -102,8 +102,6 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
                     WebDriverConfiguration.DEFAULT_SELENIUM_SERVER_ARGS);
         }
 
-        Validate.isEmpty(configuration.getSeleniumServerArgs(), " Property SeleniumServerArgs is not set.");
-
         // construct capabilities
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(getCapabilities(configuration, true));
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -95,6 +95,15 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
 
         Validate.isEmpty(configuration.getBrowser(), "The browser is not set.");
 
+        String seleniumServerArgs = configuration.getSeleniumServerArgs();
+        if (Validate.empty(seleniumServerArgs)) {
+            configuration.setSeleniumServerArgs(WebDriverConfiguration.DEFAULT_SELENIUM_SERVER_ARGS);
+            log.log(Level.INFO, "Property \"seleniumServerArgs\" was not specified, using default value of {0}",
+                    WebDriverConfiguration.DEFAULT_SELENIUM_SERVER_ARGS);
+        }
+
+        Validate.isEmpty(configuration.getSeleniumServerArgs(), " Property SeleniumServerArgs is not set.");
+
         // construct capabilities
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(getCapabilities(configuration, true));
 
@@ -107,7 +116,7 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
                         new SeleniumServerBinaryHandler(desiredCapabilities).downloadAndPrepare().toString();
                     if (!Validate.empty(seleniumServer)) {
                         startSeleniumServerEvent
-                            .fire(new StartSeleniumServer(seleniumServer, browser, desiredCapabilities, remoteAddress));
+                            .fire(new StartSeleniumServer(seleniumServer, browser, desiredCapabilities, remoteAddress, seleniumServerArgs));
                     }
                 } catch (Exception e) {
                     throw new IllegalStateException(

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutorTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutorTestCase.java
@@ -1,0 +1,7 @@
+package org.jboss.arquillian.drone.webdriver.binary.process;
+
+/**
+ * Created by hemani on 1/23/17.
+ */
+public class SeleniumServerExecutorTestCase {
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutorTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutorTestCase.java
@@ -1,7 +1,0 @@
-package org.jboss.arquillian.drone.webdriver.binary.process;
-
-/**
- * Created by hemani on 1/23/17.
- */
-public class SeleniumServerExecutorTestCase {
-}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
@@ -131,6 +131,6 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     }
 
     private void cleanUpStreams() {
-        System.setOut(null);
+        System.setOut(System.out);
     }
 }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
@@ -1,7 +1,7 @@
 package org.jboss.arquillian.drone.webdriver.binary.process;
 
-import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.drone.webdriver.binary.handler.SeleniumServerBinaryHandler;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 import org.jboss.arquillian.test.test.AbstractTestTestBase;
 import org.junit.After;
@@ -12,6 +12,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.net.URL;
 import java.util.List;
 import java.util.logging.Handler;
@@ -20,11 +21,16 @@ import java.util.logging.StreamHandler;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class SeleniumServerTestCase extends AbstractTestTestBase {
 
     private static Logger log = Logger.getLogger(SeleniumServerExecutor.class.toString());
     private OutputStream logCapturingStream;
     private StreamHandler customLogHandler;
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
     private String seleniumServerBinary;
     private DesiredCapabilities capabilities;
@@ -41,53 +47,88 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
                 new SeleniumServerBinaryHandler(new DesiredCapabilities()).downloadAndPrepare().toString();
         capabilities = new DesiredCapabilities();
         url = new URL("http://localhost:4444/wd/hub/");
+
         attachLogCapture();
+        setUpStreams();
     }
 
     @Test
-    public void test_command_contains_serverArgs() throws Exception {
+    @InSequence(1)
+    public void should_start_selenium_server_with_serverArgs_debug() throws Exception {
 
         final String browser = "chrome";
-        final String seleniumServerArgs = "-debug";
+        final String seleniumServerArgs = "-debug -role node";
 
         fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, url, seleniumServerArgs));
 
-        final String capturedLog = getTestCapturedLog();
-        final String output = parseLogger(capturedLog);
+        final String command = parseLogger();
 
-        Assertions.assertThat(output.contains(seleniumServerArgs));
+        assertThat(command).contains(seleniumServerArgs);
+        assertThat(outContent.toString()).contains("DEBUG");
     }
 
     @Test
-    public void test_command_does_not_contain_serverArgs() throws Exception {
+    @InSequence(2)
+    public void should_start_selenium_server_with_no_serverArgs() throws Exception {
 
         final String browser = "chrome";
 
         fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, url, null));
 
-        final String capturedLog = getTestCapturedLog();
-        final String output = parseLogger(capturedLog);
+        final String command = parseLogger();
 
-        Assertions.assertThat(output.endsWith(String.valueOf(url.getPort())));
+        assertThat(command).endsWith(String.valueOf(url.getPort()));
+        assertThat(outContent.toString()).contains("Selenium Server is up and running");
+    }
+
+    @Test
+    @InSequence(3)
+    public void should_start_selenium_server_with_hub_and_node() throws Exception {
+
+        final String browser = "chrome";
+
+        // start selenium Grid Hub at port 4444
+        String seleniumServerArgs = "-role hub -browserTimeout 1000";
+
+        fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, url, seleniumServerArgs));
+
+        String hubCommand = parseLogger();
+
+        assertThat(hubCommand).contains(seleniumServerArgs);
+        assertThat(outContent.toString()).contains("Selenium Grid hub is up and running");
+
+        // start selenium grid node at port 5555 and register it with the Hub.
+        String seleniumServerArgs2 = "-role node";
+        URL nodeUrl = new URL("http://localhost:5555");
+
+        fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, nodeUrl, seleniumServerArgs2));
+
+        String nodeCommand = parseLogger();
+
+        assertThat(nodeCommand).contains(seleniumServerArgs2);
+        assertThat(outContent.toString()).contains("The node is registered to the hub and ready to use");
     }
 
     @After
-    public void stopSeleniumServer(){
+    public void stopSeleniumServer() {
+        cleanUpStreams();
         fire(new AfterSuite());
     }
 
-    private String parseLogger(String capturedLog) {
+    private String parseLogger() throws IOException {
 
+        final String capturedLog = getTestCapturedLog();
         final String expectedLogPart = "Running Selenium server process: java .*$";
+
         final Pattern pattern = Pattern.compile(expectedLogPart);
         final Matcher matcher = pattern.matcher(capturedLog);
-        String line;
+        String command;
 
         if (matcher.find()) ;
         {
-            line = matcher.group();
+            command = matcher.group();
         }
-        return line;
+        return command;
     }
 
     private void attachLogCapture() {
@@ -100,5 +141,15 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     private String getTestCapturedLog() throws IOException {
         customLogHandler.flush();
         return logCapturingStream.toString();
+    }
+
+    private void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    private void cleanUpStreams() {
+        System.setOut(null);
+        System.setErr(null);
     }
 }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
@@ -1,0 +1,104 @@
+package org.jboss.arquillian.drone.webdriver.binary.process;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.arquillian.drone.webdriver.binary.handler.SeleniumServerBinaryHandler;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+import org.jboss.arquillian.test.test.AbstractTestTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SeleniumServerTestCase extends AbstractTestTestBase {
+
+    private static Logger log = Logger.getLogger(SeleniumServerExecutor.class.toString());
+    private OutputStream logCapturingStream;
+    private StreamHandler customLogHandler;
+
+    private String seleniumServerBinary;
+    private DesiredCapabilities capabilities;
+    private URL url;
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        extensions.add(SeleniumServerExecutor.class);
+    }
+
+    @Before
+    public void initialise() throws Exception {
+        seleniumServerBinary =
+                new SeleniumServerBinaryHandler(new DesiredCapabilities()).downloadAndPrepare().toString();
+        capabilities = new DesiredCapabilities();
+        url = new URL("http://localhost:4444/wd/hub/");
+        attachLogCapture();
+    }
+
+    @Test
+    public void test_command_contains_serverArgs() throws Exception {
+
+        final String browser = "chrome";
+        final String seleniumServerArgs = "-debug";
+
+        fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, url, seleniumServerArgs));
+
+        final String capturedLog = getTestCapturedLog();
+        final String output = parseLogger(capturedLog);
+
+        Assertions.assertThat(output.contains(seleniumServerArgs));
+    }
+
+    @Test
+    public void test_command_does_not_contain_serverArgs() throws Exception {
+
+        final String browser = "chrome";
+
+        fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, url, null));
+
+        final String capturedLog = getTestCapturedLog();
+        final String output = parseLogger(capturedLog);
+
+        Assertions.assertThat(output.endsWith(String.valueOf(url.getPort())));
+    }
+
+    @After
+    public void stopSeleniumServer(){
+        fire(new AfterSuite());
+    }
+
+    private String parseLogger(String capturedLog) {
+
+        final String expectedLogPart = "Running Selenium server process: java .*$";
+        final Pattern pattern = Pattern.compile(expectedLogPart);
+        final Matcher matcher = pattern.matcher(capturedLog);
+        String line;
+
+        if (matcher.find()) ;
+        {
+            line = matcher.group();
+        }
+        return line;
+    }
+
+    private void attachLogCapture() {
+        logCapturingStream = new ByteArrayOutputStream();
+        Handler[] handlers = log.getParent().getHandlers();
+        customLogHandler = new StreamHandler(logCapturingStream, handlers[0].getFormatter());
+        log.addHandler(customLogHandler);
+    }
+
+    private String getTestCapturedLog() throws IOException {
+        customLogHandler.flush();
+        return logCapturingStream.toString();
+    }
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
@@ -1,7 +1,6 @@
 package org.jboss.arquillian.drone.webdriver.binary.process;
 
 import org.jboss.arquillian.drone.webdriver.binary.handler.SeleniumServerBinaryHandler;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 import org.jboss.arquillian.test.test.AbstractTestTestBase;
 import org.junit.After;
@@ -30,7 +29,6 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     private StreamHandler customLogHandler;
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
     private String seleniumServerBinary;
     private DesiredCapabilities capabilities;
@@ -46,7 +44,7 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
         seleniumServerBinary =
                 new SeleniumServerBinaryHandler(new DesiredCapabilities()).downloadAndPrepare().toString();
         capabilities = new DesiredCapabilities();
-        url = new URL("http://localhost:4444/wd/hub/");
+        url = new URL("http://localhost:5555/wd/hub/");
 
         attachLogCapture();
         setUpStreams();
@@ -130,11 +128,9 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
 
     private void setUpStreams() {
         System.setOut(new PrintStream(outContent));
-        System.setErr(new PrintStream(errContent));
     }
 
     private void cleanUpStreams() {
         System.setOut(null);
-        System.setErr(null);
     }
 }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
@@ -53,7 +53,6 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     }
 
     @Test
-    @InSequence(1)
     public void should_start_selenium_server_with_serverArgs_debug() throws Exception {
 
         final String browser = "chrome";
@@ -68,7 +67,6 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     }
 
     @Test
-    @InSequence(2)
     public void should_start_selenium_server_with_no_serverArgs() throws Exception {
 
         final String browser = "chrome";
@@ -82,12 +80,10 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     }
 
     @Test
-    @InSequence(3)
-    public void should_start_selenium_server_with_hub_and_node() throws Exception {
+    public void should_start_selenium_server_as_hub() throws Exception {
 
         final String browser = "chrome";
 
-        // start selenium Grid Hub at port 4444
         String seleniumServerArgs = "-role hub -browserTimeout 1000";
 
         fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, url, seleniumServerArgs));
@@ -96,17 +92,6 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
 
         assertThat(hubCommand).contains(seleniumServerArgs);
         assertThat(outContent.toString()).contains("Selenium Grid hub is up and running");
-
-        // start selenium grid node at port 5555 and register it with the Hub.
-        String seleniumServerArgs2 = "-role node";
-        URL nodeUrl = new URL("http://localhost:5555");
-
-        fire(new StartSeleniumServer(seleniumServerBinary, browser, capabilities, nodeUrl, seleniumServerArgs2));
-
-        String nodeCommand = parseLogger();
-
-        assertThat(nodeCommand).contains(seleniumServerArgs2);
-        assertThat(outContent.toString()).contains("The node is registered to the hub and ready to use");
     }
 
     @After

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
@@ -98,10 +98,13 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
         initializationParameter = new InitializationParameter(hubUrl, desiredCapabilities);
 
         try {
+            System.setProperty("browser","chrome");
             String browser = System.getProperty("browser");
+            System.setProperty("seleniumServerArgs", "");
+            String seleniumServerArgs = System.getProperty("seleniumServerArgs");
             String seleniumServerBinary =
                 new SeleniumServerBinaryHandler(new DesiredCapabilities()).downloadAndPrepare().toString();
-            fire(new StartSeleniumServer(seleniumServerBinary, browser, new DesiredCapabilities(), hubUrl));
+            fire(new StartSeleniumServer(seleniumServerBinary, browser, new DesiredCapabilities(), hubUrl, seleniumServerArgs));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
@@ -98,9 +98,7 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
         initializationParameter = new InitializationParameter(hubUrl, desiredCapabilities);
 
         try {
-            System.setProperty("browser","chrome");
             String browser = System.getProperty("browser");
-            System.setProperty("seleniumServerArgs", "");
             String seleniumServerArgs = System.getProperty("seleniumServerArgs");
             String seleniumServerBinary =
                 new SeleniumServerBinaryHandler(new DesiredCapabilities()).downloadAndPrepare().toString();
@@ -126,6 +124,7 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
         when(configuration.isRemoteReusable()).thenReturn(true);
         when(configuration.getCapabilities()).thenReturn(desiredCapabilities);
         when(configuration.getRemoteAddress()).thenReturn(hubUrl);
+        when(configuration.getSeleniumServerArgs()).thenReturn("-debug");
 
         // when
         fire(new BeforeSuite());
@@ -154,6 +153,7 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
         when(configuration.isRemoteReusable()).thenReturn(true);
         when(configuration.getCapabilities()).thenReturn(desiredCapabilities);
         when(configuration.getRemoteAddress()).thenReturn(hubUrl);
+        when(configuration.getSeleniumServerArgs()).thenReturn("-debug");
 
         // when
         fire(new BeforeSuite());


### PR DESCRIPTION
#### Short description of what this resolves:

Adds the possibility to allow user to specify additional arguments [example: -debug -role hub -browserTimeout 1000] to the selenium server that is run internally

#### Changes proposed in this pull request:

- Adds `seleniumServerArgs` as a new `arquillian.xml` property which would be a simple string with arguments  defined.
- Appends the defined arguments to the build command that launches the selenium server.
- Updates necessary tests to include the new property.

**Fixes**: #71  
