### PR TITLE
ARQ-2080 remote webdriver is closed even when the session is persisted

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -184,9 +184,8 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
             ReusedSession session = ReusedSession.createInstance(sessionId, driverCapabilities);
             sessionStore.get().store(param, session);
             persistEvent.fire(new PersistReusedSessionsEvent());
-        } else {
-            driver.quit();
         }
+        driver.quit();
     }
 
     @Override


### PR DESCRIPTION
otherwise, when the test ReusableRemoteWebDriverTestCase was run, then the browser wouldn't be closed