### PR TITLE
ARQ-2080 Drone keeps the latest RemoteWebDriver whose reusable session was persisted and in AfterClass it tries to destroy it

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -22,6 +22,8 @@ import java.util.logging.Logger;
 
 import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.drone.spi.Configurator;
 import org.jboss.arquillian.drone.spi.Destructor;
@@ -34,6 +36,7 @@ import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.Initializati
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.InitializationParametersMap;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.PersistReusedSessionsEvent;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusableRemoteWebDriver;
+import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusableRemoteWebDriverToDestroy;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusedSession;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusedSessionStore;
 import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.UnableReuseSessionException;
@@ -66,6 +69,10 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
     private Event<PersistReusedSessionsEvent> persistEvent;
     @Inject
     private Event<StartSeleniumServer> startSeleniumServerEvent;
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<ReusableRemoteWebDriverToDestroy> lastRemoteWebDriverToDestroy;
 
     @Override
     public int getPrecedence() {
@@ -184,6 +191,7 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
             ReusedSession session = ReusedSession.createInstance(sessionId, driverCapabilities);
             sessionStore.get().store(param, session);
             persistEvent.fire(new PersistReusedSessionsEvent());
+            lastRemoteWebDriverToDestroy.set(new ReusableRemoteWebDriverToDestroy(driver));
         } else {
             driver.quit();
         }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/ReusableRemoteWebDriverExtension.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/ReusableRemoteWebDriverExtension.java
@@ -23,6 +23,7 @@ import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
+import org.jboss.arquillian.test.spi.event.suite.AfterClass;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 
 /**
@@ -67,5 +68,9 @@ public class ReusableRemoteWebDriverExtension {
 
     public void persistStore(@Observes PersistReusedSessionsEvent event) {
         permanentStorage.get().writeStore(storeInstance.get());
+    }
+
+    public void destroyLastRemoteWebDriver(@Observes AfterClass event, ReusableRemoteWebDriverToDestroy toDestroy){
+        toDestroy.destroy();
     }
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/ReusableRemoteWebDriverToDestroy.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/ReusableRemoteWebDriverToDestroy.java
@@ -1,0 +1,38 @@
+package org.jboss.arquillian.drone.webdriver.factory.remote.reusable;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class ReusableRemoteWebDriverToDestroy {
+
+    private Logger log = Logger.getLogger(ReusableRemoteWebDriverToDestroy.class.getName());
+
+    private boolean destroyed = false;
+
+    private RemoteWebDriver remoteWebDriver;
+
+    public ReusableRemoteWebDriverToDestroy(RemoteWebDriver remoteWebDriver) {
+        this.remoteWebDriver = remoteWebDriver;
+    }
+
+    public void setRemoteWebDriver(RemoteWebDriver remoteWebDriver) {
+        this.remoteWebDriver = remoteWebDriver;
+    }
+
+    public void destroy() {
+        if (!destroyed) {
+            try {
+                remoteWebDriver.quit();
+            } catch (WebDriverException e) {
+                log.log(Level.WARNING, "@Drone {0} has been already destroyed and can't be destroyed again.",
+                        remoteWebDriver.getClass().getSimpleName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented a registry ReusableRemoteWebDriverToDestroy where I store the latest driver that was used with a reusable session. Then in AfterClass phase, this webdriver is destroyed. 
The reason is that when the reusable session was persisted, then the remote webdriver instance wasn't destroyed. As a result of this, a browser wasn't closed in tests:
ReusableRemoteWebDriverTestCase
TestReusingRemoteWebDriverSession