### PR TITLE
PhantomJS is downloaded using Spacelift

### DIFF
--- a/depchain/pom.xml
+++ b/depchain/pom.xml
@@ -108,14 +108,19 @@
             <version>${version.selenium}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-phantom-driver</artifactId>
-            <version>${version.phantom.driver}</version>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-safari-driver</artifactId>
+            <version>${version.selenium}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-edge-driver</artifactId>
             <version>${version.selenium}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.codeborne</groupId>
+            <artifactId>phantomjsdriver</artifactId>
+            <version>${phantomjs.driver.version}</version>
         </dependency>
     </dependencies>
 

--- a/drone-bom/pom.xml
+++ b/drone-bom/pom.xml
@@ -39,9 +39,9 @@
     </developers>
 
     <properties>
-        <version.org.jboss.arquillian.phantom.driver>1.2.1.1</version.org.jboss.arquillian.phantom.driver>
         <version.org.jboss.arquillian.selenium>3.3.1</version.org.jboss.arquillian.selenium>
         <version.htmlunit.driver>2.24</version.htmlunit.driver>
+        <phantomjs.driver.version>1.4.1</phantomjs.driver.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
     </properties>
@@ -108,11 +108,11 @@
                 <version>${version.htmlunit.driver}</version>
             </dependency>
 
-            <!-- PhantomDriver is kept externally from Selenium BOM -->
+            <!-- Ghost Driver is kept externally from Selenium BOM -->
             <dependency>
-                <groupId>org.jboss.arquillian.extension</groupId>
-                <artifactId>arquillian-phantom-driver</artifactId>
-                <version>${version.org.jboss.arquillian.phantom.driver}</version>
+                <groupId>com.codeborne</groupId>
+                <artifactId>phantomjsdriver</artifactId>
+                <version>${phantomjs.driver.version}</version>
             </dependency>
 
             <!-- Dependency Chain -->

--- a/drone-build/pom.xml
+++ b/drone-build/pom.xml
@@ -169,12 +169,10 @@
                 <artifactId>htmlunit-driver</artifactId>
                 <version>${version.htmlunit.driver}</version>
             </dependency>
-
-            <!-- PhanthomJS dependencies not present in the Selenium BOM file -->
             <dependency>
-                <groupId>org.jboss.arquillian.extension</groupId>
-                <artifactId>arquillian-phantom-driver</artifactId>
-                <version>${version.phantom.driver}</version>
+                <groupId>com.codeborne</groupId>
+                <artifactId>phantomjsdriver</artifactId>
+                <version>${phantomjs.driver.version}</version>
             </dependency>
 
             <!-- Testing dependencies -->

--- a/drone-webdriver/pom.xml
+++ b/drone-webdriver/pom.xml
@@ -47,7 +47,6 @@
             <version>${project.version}</version>
         </dependency>
 
-
         <!-- Arquillian dependencies -->
         <dependency>
             <groupId>org.jboss.arquillian.core</groupId>
@@ -101,19 +100,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-phantom-driver</artifactId>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-edge-driver</artifactId>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-edge-driver</artifactId>
+            <artifactId>selenium-safari-driver</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.codeborne</groupId>
+            <artifactId>phantomjsdriver</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -132,6 +130,11 @@
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.8.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>21.0</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -202,6 +205,13 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <default.supported.phantomjs.binary.version>
+                                    ${default.supported.phantomjs.binary.version}
+                                </default.supported.phantomjs.binary.version>
+                            </systemPropertyVariables>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>default-test</id>

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/BinaryFilesUtils.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/BinaryFilesUtils.java
@@ -1,5 +1,10 @@
 package org.jboss.arquillian.drone.webdriver.binary;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.arquillian.spacelift.Spacelift;
+import org.arquillian.spacelift.task.archive.UntarTool;
+import org.arquillian.spacelift.task.archive.UnzipTool;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -7,11 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 import java.util.logging.Logger;
-
-import org.apache.commons.codec.digest.DigestUtils;
-import org.arquillian.spacelift.Spacelift;
-import org.arquillian.spacelift.task.archive.UntarTool;
-import org.arquillian.spacelift.task.archive.UnzipTool;
 
 import static org.jboss.arquillian.drone.webdriver.utils.Constants.DRONE_TARGET_DIRECTORY;
 
@@ -41,7 +41,7 @@ public class BinaryFilesUtils {
             dir = UUID.randomUUID().toString();
         }
         File targetDir = new File(DRONE_TARGET_DIRECTORY + File.separator + dir);
-        if (!targetDir.exists() || targetDir.listFiles(file -> file.isFile()).length == 0) {
+        if (!targetDir.exists() || targetDir.listFiles().length == 0) {
 
             targetDir.mkdirs();
             String filePath = toExtract.getAbsolutePath();

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GeckoDriverGitHubSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GeckoDriverGitHubSource.java
@@ -2,7 +2,7 @@ package org.jboss.arquillian.drone.webdriver.binary.downloading.source;
 
 import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
 import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
-import org.jboss.arquillian.phantom.resolver.maven.PlatformUtils;
+import org.jboss.arquillian.drone.webdriver.utils.PlatformUtils;
 
 public class GeckoDriverGitHubSource extends GitHubSource {
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
@@ -77,21 +77,21 @@ public abstract class GitHubSource implements ExternalBinarySource {
             String tagName = latestRelease.get(tagNameKey).getAsString();
             binaryRelease = new ExternalBinary(tagName);
             binaryRelease.setUrl(findReleaseBinaryUrl(latestRelease, binaryRelease.getVersion()));
-            cache.store(binaryRelease, this.uniqueKey, extractModificationDate(response));
+            cache.store(binaryRelease, uniqueKey, extractModificationDate(response));
         } else {
             binaryRelease = cache.load(uniqueKey, ExternalBinary.class);
         }
         return binaryRelease;
     }
 
-    private Map<String, String> lastModificationHeader() {
+    protected Map<String, String> lastModificationHeader() {
         final Map<String, String> headers = new HashMap<>();
-        headers.put(IF_MODIFIED_SINCE, cache.lastModificationOf(this.uniqueKey).withZoneSameInstant(ZoneId.of("GMT")).format(Rfc2126DateTimeFormatter.INSTANCE));
+        headers.put(IF_MODIFIED_SINCE, cache.lastModificationOf(uniqueKey).withZoneSameInstant(ZoneId.of("GMT")).format(Rfc2126DateTimeFormatter.INSTANCE));
         System.out.println(headers);
         return headers;
     }
 
-    private ZonedDateTime extractModificationDate(HttpClient.Response response) {
+    protected ZonedDateTime extractModificationDate(HttpClient.Response response) {
         final String modificationDate = response.getHeader(LAST_MODIFIED);
         final DateTimeFormatter dateTimeFormatter = Rfc2126DateTimeFormatter.INSTANCE;
         return ZonedDateTime.parse(modificationDate, dateTimeFormatter);
@@ -118,7 +118,7 @@ public abstract class GitHubSource implements ExternalBinarySource {
         return null;
     }
 
-    private String findReleaseBinaryUrl(JsonObject releaseObject, String version) throws Exception {
+    protected String findReleaseBinaryUrl(JsonObject releaseObject, String version) throws Exception {
         final JsonArray assets = releaseObject.get(assetsKey).getAsJsonArray();
         for (JsonElement asset : assets) {
             JsonObject assetJson = asset.getAsJsonObject();
@@ -155,8 +155,24 @@ public abstract class GitHubSource implements ExternalBinarySource {
         return result;
     }
 
-    private HttpClient.Response sentGetRequestWithPagination(String url, int pageNumber, Map<String, String> headers) throws Exception {
+    protected HttpClient.Response sentGetRequestWithPagination(String url, int pageNumber, Map<String, String> headers) throws Exception {
         final URI uri = new URIBuilder(url).setParameter("page", String.valueOf(pageNumber)).build();
         return httpClient.get(uri.toString(), headers);
+    }
+
+    protected String getProjectUrl(){
+        return projectUrl;
+    }
+
+    protected Gson getGson(){
+        return gson;
+    }
+
+    protected String getUniqueKey(){
+        return uniqueKey;
+    }
+
+    protected GitHubLastUpdateCache getCache(){
+        return cache;
     }
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
@@ -87,7 +87,6 @@ public abstract class GitHubSource implements ExternalBinarySource {
     protected Map<String, String> lastModificationHeader() {
         final Map<String, String> headers = new HashMap<>();
         headers.put(IF_MODIFIED_SINCE, cache.lastModificationOf(uniqueKey).withZoneSameInstant(ZoneId.of("GMT")).format(Rfc2126DateTimeFormatter.INSTANCE));
-        System.out.println(headers);
         return headers;
     }
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
@@ -77,8 +77,6 @@ public class PhantomJSGitHubBitbucketSource extends GitHubSource {
                 phantomJsUrl.append("x86_64.tar.bz2").toString();
             }
         }
-
-        System.out.println(phantomJsUrl.toString());
         return phantomJsUrl.toString();
     }
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
@@ -1,0 +1,95 @@
+package org.jboss.arquillian.drone.webdriver.binary.downloading.source;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
+import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
+import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
+import org.jboss.arquillian.drone.webdriver.utils.PlatformUtils;
+
+import static org.jboss.arquillian.drone.webdriver.binary.handler.PhantomJSDriverBinaryHandler.PHANTOMJS_BINARY_NAME;
+
+/**
+ * A slightly changed {@link GitHubSource} implementation handling PhantomJS binaries. The latest version is retrieved
+ * from list of GH tags and download URL is constructed to use Bitbucket downloads storage.
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class PhantomJSGitHubBitbucketSource extends GitHubSource {
+
+    private static String TAGS_URL = "/tags";
+    private static String TAG_NAME = "name";
+
+    private static String BASE_DOWNLOAD_URL = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-";
+
+    public PhantomJSGitHubBitbucketSource(HttpClient httpClient, GitHubLastUpdateCache gitHubLastUpdateCache) {
+        super("ariya", "phantomjs", httpClient, gitHubLastUpdateCache);
+    }
+
+    @Override
+    public ExternalBinary getLatestRelease() throws Exception {
+
+        final HttpClient.Response response =
+            sentGetRequestWithPagination(getProjectUrl() + TAGS_URL, 1, lastModificationHeader());
+        final ExternalBinary latestPhantomJSBinary;
+
+        if (response.hasPayload()) {
+            JsonArray releaseTags = getGson().fromJson(response.getPayload(), JsonElement.class).getAsJsonArray();
+            if (releaseTags.size() == 0){
+                return null;
+            }
+            String version = releaseTags.get(0).getAsJsonObject().get(TAG_NAME).getAsString();
+            latestPhantomJSBinary = new ExternalBinary(version);
+
+            latestPhantomJSBinary.setUrl(getUrlForVersion(version));
+            getCache().store(latestPhantomJSBinary, getUniqueKey(), extractModificationDate(response));
+        } else {
+            latestPhantomJSBinary = getCache().load(getUniqueKey(), ExternalBinary.class);
+        }
+
+        return latestPhantomJSBinary;
+    }
+
+
+    @Override
+    public ExternalBinary getReleaseForVersion(String version) throws Exception {
+        ExternalBinary phantomJSBinary = new ExternalBinary(version);
+        phantomJSBinary.setUrl(getUrlForVersion(version));
+        return  phantomJSBinary;
+    }
+
+
+    private String getUrlForVersion(String version){
+        StringBuilder phantomJsUrl = new StringBuilder(BASE_DOWNLOAD_URL);
+        phantomJsUrl.append(version).append("-");
+
+        if (PlatformUtils.isMac()) {
+            phantomJsUrl.append("macosx.zip").toString();
+
+        } else if (PlatformUtils.isWindows()) {
+            phantomJsUrl.append("windows.zip");
+
+        } else {
+            phantomJsUrl.append("linux-");
+            if (PlatformUtils.is32()) {
+                phantomJsUrl.append("i686.tar.bz2").toString();
+            } else {
+                phantomJsUrl.append("x86_64.tar.bz2").toString();
+            }
+        }
+
+        System.out.println(phantomJsUrl.toString());
+        return phantomJsUrl.toString();
+    }
+
+
+
+    @Override
+    protected String getExpectedFileNameRegex(String version) {
+        return PHANTOMJS_BINARY_NAME;
+    }
+
+
+
+}
+

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/AbstractBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/AbstractBinaryHandler.java
@@ -1,9 +1,5 @@
 package org.jboss.arquillian.drone.webdriver.binary.handler;
 
-import java.io.File;
-import java.net.URL;
-import java.util.logging.Logger;
-
 import org.jboss.arquillian.drone.webdriver.binary.BinaryFilesUtils;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.Downloader;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
@@ -12,6 +8,10 @@ import org.jboss.arquillian.drone.webdriver.utils.Constants;
 import org.jboss.arquillian.drone.webdriver.utils.PropertySecurityAction;
 import org.jboss.arquillian.drone.webdriver.utils.Validate;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.File;
+import java.net.URL;
+import java.util.logging.Logger;
 
 /**
  * Class that handles system properties, properties stored in capabilities, downloading, extracting and setting binaries
@@ -185,7 +185,7 @@ public abstract class AbstractBinaryHandler implements BinaryHandler {
         File downloaded = Downloader.download(targetDir, from);
         File extraction = BinaryFilesUtils.extract(downloaded);
         File[] files = extraction.listFiles(file -> file.isFile());
-        if (files.length == 0) {
+        if (files == null || files.length == 0) {
             throw new IllegalStateException(
                 "The number of extracted files in the directory " + extraction + " is 0. There is no file to use");
         }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
@@ -4,7 +4,7 @@ import org.jboss.arquillian.drone.webdriver.binary.downloading.source.ExternalBi
 import org.jboss.arquillian.drone.webdriver.binary.downloading.source.GoogleStorageSource;
 import org.jboss.arquillian.drone.webdriver.factory.BrowserCapabilitiesList;
 import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
-import org.jboss.arquillian.phantom.resolver.maven.PlatformUtils;
+import org.jboss.arquillian.drone.webdriver.utils.PlatformUtils;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.regex.Pattern;

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/InternetExplorerBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/InternetExplorerBinaryHandler.java
@@ -4,7 +4,7 @@ import org.jboss.arquillian.drone.webdriver.binary.downloading.source.ExternalBi
 import org.jboss.arquillian.drone.webdriver.binary.downloading.source.SeleniumGoogleStorageSource;
 import org.jboss.arquillian.drone.webdriver.factory.BrowserCapabilitiesList;
 import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
-import org.jboss.arquillian.phantom.resolver.maven.PlatformUtils;
+import org.jboss.arquillian.drone.webdriver.utils.PlatformUtils;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.io.File;

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/PlatformUtils.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/PlatformUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver.utils;
+
+public class PlatformUtils {
+
+    public static String OS = System.getProperty("os.name").toLowerCase();
+    public static String ARCH = System.getProperty("os.arch").toLowerCase();
+
+    public enum OperatingSystem {
+        WINDOWS, UNIX, MACOSX, SOLARIS, UNKNOWN;
+    }
+
+    public enum Architecture {
+        BIT64, BIT32;
+    }
+
+    private PlatformUtils() {
+    }
+
+    public static boolean isWindows() {
+        return OS.contains("win");
+    }
+
+    public static boolean isMac() {
+        return OS.contains("mac");
+    }
+
+    public static boolean isUnix() {
+        return OS.contains("nix") || OS.contains("nux") || OS.contains("aix");
+    }
+
+    public static boolean isSolaris() {
+        return OS.contains("sunos");
+    }
+
+    public static boolean is64() {
+        return System.getProperty("os.arch").contains("64");
+    }
+
+    public static boolean is32() {
+        return !is64();
+    }
+
+    public static Platform platform() {
+        return new Platform() {
+            public OperatingSystem os() {
+                if (isWindows()) {
+                    return OperatingSystem.WINDOWS;
+                } else if (isUnix()) {
+                    return OperatingSystem.UNIX;
+                } else if (isMac()) {
+                    return OperatingSystem.MACOSX;
+                } else if (isSolaris()) {
+                    return OperatingSystem.SOLARIS;
+                } else {
+                    return OperatingSystem.UNKNOWN;
+                }
+            }
+
+            public Architecture arch() {
+                return is64() ? Architecture.BIT64 : Architecture.BIT32;
+            }
+        };
+    }
+
+    public interface Platform {
+        OperatingSystem os();
+
+        Architecture arch();
+    }
+
+}

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Validate.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Validate.java
@@ -16,12 +16,21 @@
  */
 package org.jboss.arquillian.drone.webdriver.utils;
 
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import org.openqa.selenium.Platform;
+
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 import java.util.logging.Logger;
+
+import static org.openqa.selenium.Platform.WINDOWS;
 
 /**
  * @author <a href="kpiwko@redhat.com">Karel Piwko</a>
@@ -30,6 +39,8 @@ import java.util.logging.Logger;
 public class Validate {
 
     private static final FileExecutableChecker fileExecutableChecker = new FileExecutableChecker();
+    private static final ImmutableSet<String> ENDINGS = Platform.getCurrent().is(WINDOWS) ?
+        ImmutableSet.of("", ".cmd", ".exe", ".com", ".bat") : ImmutableSet.of("");
 
     public static boolean empty(Object object) {
         return object == null;
@@ -84,6 +95,71 @@ public class Validate {
     public static void isExecutable(String path, String message) throws IllegalArgumentException {
         if (!executable(path)) {
             throw new IllegalArgumentException(message);
+        }
+    }
+
+    /**
+     * Find the executable by scanning the file system and the PATH. In the case of Windows this
+     * method allows common executable endings (".com", ".bat" and ".exe") to be omitted.
+     *
+     * @param command The name of the executable to find
+     * @return Whether the command is executable or not.
+     */
+    public static boolean isCommandExecutable(String command) throws IllegalArgumentException {
+        File file = new File(command);
+        if (fileExecutableChecker.canExecute(file)) {
+            return true;
+        }
+
+        if (Platform.getCurrent().is(WINDOWS)) {
+            file = new File(command + ".exe");
+            if (fileExecutableChecker.canExecute(file)) {
+                return true;
+            }
+        }
+
+        final ImmutableSet.Builder<String> pathSegmentBuilder = new ImmutableSet.Builder<>();
+        addPathFromEnvironment(pathSegmentBuilder);
+        if (Platform.getCurrent().is(Platform.MAC)) {
+            addMacSpecificPath(pathSegmentBuilder);
+        }
+
+        for (String pathSegment : pathSegmentBuilder.build()) {
+            for (String ending : ENDINGS) {
+                file = new File(pathSegment, command + ending);
+                if (fileExecutableChecker.canExecute(file)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void addPathFromEnvironment(final ImmutableSet.Builder<String> pathSegmentBuilder) {
+        String pathName = "PATH";
+        Map<String, String> env = System.getenv();
+        if (!env.containsKey(pathName)) {
+            for (String key : env.keySet()) {
+                if (pathName.equalsIgnoreCase(key)) {
+                    pathName = key;
+                    break;
+                }
+            }
+        }
+        String path = env.get(pathName);
+        if (path != null) {
+            pathSegmentBuilder.add(path.split(File.pathSeparator));
+        }
+    }
+
+    private static void addMacSpecificPath(final ImmutableSet.Builder<String> pathSegmentBuilder) {
+        File pathFile = new File("/etc/paths");
+        if (pathFile.exists()) {
+            try {
+                pathSegmentBuilder.addAll(Files.readLines(pathFile, Charsets.UTF_8));
+            } catch (IOException e) {
+                // Guess we won't include those, then
+            }
         }
     }
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Validate.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Validate.java
@@ -38,6 +38,8 @@ import static org.openqa.selenium.Platform.WINDOWS;
  */
 public class Validate {
 
+    private static final Logger log = Logger.getLogger(Validate.class.getName());
+
     private static final FileExecutableChecker fileExecutableChecker = new FileExecutableChecker();
     private static final ImmutableSet<String> ENDINGS = Platform.getCurrent().is(WINDOWS) ?
         ImmutableSet.of("", ".cmd", ".exe", ".com", ".bat") : ImmutableSet.of("");
@@ -158,7 +160,8 @@ public class Validate {
             try {
                 pathSegmentBuilder.addAll(Files.readLines(pathFile, Charsets.UTF_8));
             } catch (IOException e) {
-                // Guess we won't include those, then
+                log.warning(
+                    String.format("There was an error when the file %s was being read: %s", pathFile, e.getMessage()));
             }
         }
     }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseFromTagsTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseFromTagsTestCase.java
@@ -1,0 +1,178 @@
+package org.jboss.arquillian.drone.webdriver.binary.downloading.source;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+import io.specto.hoverfly.junit.dsl.ResponseBuilder;
+import io.specto.hoverfly.junit.rule.HoverflyRule;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
+import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
+import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+
+import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
+import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class GitHubSourceLatestReleaseFromTagsTestCase {
+
+    private static final String CACHED_CONTENT = "{\"lastModified\":\"Tue, 28 Mar 2017 05:23:15 GMT\"," +
+        "\"asset\":" +
+        "{\"version\":\"2.1.1\"," +
+        "\"url\":\"https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2\"}" +
+        "}";
+
+    @ClassRule
+    public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode();
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    private final String RESPONSE_BODY;
+    private File tmpFolder;
+    private PhantomJSGitHubBitbucketSource phantomJSSource;
+    private HttpClient httpClientSpy;
+    private GitHubLastUpdateCache cacheSpy;
+
+    public GitHubSourceLatestReleaseFromTagsTestCase() throws IOException {
+        this.RESPONSE_BODY = loadResponseBody("hoverfly/gh.simulation.ariya@phantomjs.tags.json");
+    }
+
+    @Before
+    public void wireComponentsUnderTest() throws IOException {
+        this.tmpFolder = folder.newFolder();
+        this.httpClientSpy = spy(new HttpClient());
+        this.cacheSpy = spy(new GitHubLastUpdateCache(tmpFolder));
+        this.phantomJSSource = new PhantomJSGitHubBitbucketSource(httpClientSpy, cacheSpy);
+    }
+
+    @Test
+    public void should_load_release_information_from_gh_and_store_in_cache() throws Exception {
+        // given
+        hoverflyRule.simulate(dsl(service("https://api.github.com")
+                                      .get("/repos/ariya/phantomjs/tags")
+                                      .queryParam("page", 1)
+                                      .willReturn(
+                                          ResponseBuilder.response()
+                                              .header("Last-Modified", "Tue, 28 Mar 2017 05:23:15 GMT")
+                                              .body(RESPONSE_BODY)
+                                      )));
+
+        final String expectedVersion = "2.1.1";
+
+        // when
+        final ExternalBinary latestRelease = phantomJSSource.getLatestRelease();
+
+        // then
+        softly.assertThat(latestRelease.getVersion()).isEqualTo(expectedVersion);
+        softly.assertThat(tmpFolder.listFiles()).hasSize(1);
+        softly.assertThat(tmpFolder.listFiles()[0]).isFile().hasContent(CACHED_CONTENT);
+        verify(httpClientSpy).get(anyString(), anyMap());
+        verify(cacheSpy, times(0)).load(anyString(), any());
+        verify(cacheSpy, times(1)).store(any(), anyString(), any());
+    }
+
+    @Test
+    public void should_load_release_information_from_cache_when_not_changed() throws Exception {
+        // given
+        hoverflyRule.simulate(dsl(service("https://api.github.com")
+                                      .get("/repos/ariya/phantomjs/tags")
+                                      .header(HttpHeaders.IF_MODIFIED_SINCE, "Tue, 28 Mar 2017 05:23:15 GMT")
+                                      .queryParam("page", 1)
+                                      .willReturn(
+                                          ResponseBuilder.response().status(HttpStatus.SC_NOT_MODIFIED)
+                                      )));
+        createCacheFile("gh.cache.ariya@phantomjs.json", CACHED_CONTENT);
+
+        final String expectedVersion = "2.1.1";
+
+        // when
+        final ExternalBinary latestRelease = phantomJSSource.getLatestRelease();
+
+        // then
+        softly.assertThat(latestRelease.getVersion()).isEqualTo(expectedVersion);
+        softly.assertThat(tmpFolder.listFiles()).hasSize(1);
+        softly.assertThat(tmpFolder.listFiles()[0]).isFile().hasContent(CACHED_CONTENT);
+        verify(httpClientSpy).get(anyString(), anyMap());
+        verify(cacheSpy, times(1)).load(anyString(), any());
+        verify(cacheSpy, times(0)).store(any(), anyString(), any());
+    }
+
+    @Test
+    // With this test we make sure that the internal date is converted to RFC 2126 with GMT prior to GH call
+    public void should_load_release_information_from_gh_and_overwrite_cache_when_last_modified_changed()
+        throws Exception {
+        // given
+        String cached_content =
+            "{\"lastModified\":\"Sun, 01 Jan 2017 18:16:07 +0100\"," + // Here we store the date with the offset
+                "\"asset\":" +
+                "{\"version\":\"2.1.0\"," +
+                "\"url\":\"https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.0-linux-x86_64.tar.bz2\"}"
+                +
+                "}";
+
+        hoverflyRule.simulate(dsl(service("https://api.github.com")
+                                      .get("/repos/ariya/phantomjs/tags")
+                                      .header(HttpHeaders.IF_MODIFIED_SINCE,
+                                              "Sun, 01 Jan 2017 17:16:07 GMT") // But we expect it to be sent in GMT, as this is how we match the request
+                                      .queryParam("page", 1)
+                                      .willReturn(
+                                          ResponseBuilder.response()
+                                              .header("Last-Modified", "Tue, 28 Mar 2017 05:23:15 GMT")
+                                              .body(RESPONSE_BODY)
+                                      )));
+        createCacheFile("gh.cache.ariya@phantomjs.json", cached_content);
+
+        final String expectedVersion = "2.1.1";
+
+        // when
+        final ExternalBinary latestRelease = phantomJSSource.getLatestRelease();
+
+        // then
+        softly.assertThat(latestRelease.getVersion()).isEqualTo(expectedVersion);
+        softly.assertThat(tmpFolder.listFiles()).hasSize(1);
+        softly.assertThat(tmpFolder.listFiles()[0]).isFile().hasContent(CACHED_CONTENT);
+        verify(httpClientSpy).get(anyString(), anyMap());
+        verify(cacheSpy, times(0)).load(anyString(), any());
+        verify(cacheSpy, times(1)).store(any(), anyString(), any());
+    }
+
+    private String loadResponseBody(String path) throws IOException {
+        String response;
+        ClassLoader classLoader = getClass().getClassLoader();
+        try (
+            final InputStreamReader inputStreamReader = new InputStreamReader(classLoader.getResourceAsStream(path),
+                                                                              Charsets.UTF_8)) {
+            response = CharStreams.toString(inputStreamReader);
+        }
+        return response;
+    }
+
+    private void createCacheFile(String fileName, String content) throws FileNotFoundException {
+        try (final PrintWriter printWriter = new PrintWriter(new File(tmpFolder.getAbsolutePath() + "/" + fileName))) {
+            printWriter.print(content);
+            printWriter.flush();
+        }
+    }
+
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/BinaryHandlerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/BinaryHandlerTestCase.java
@@ -1,13 +1,5 @@
 package org.jboss.arquillian.drone.webdriver.binary.handler;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.io.FileUtils;
 import org.arquillian.spacelift.Spacelift;
 import org.arquillian.spacelift.process.CommandBuilder;
@@ -17,8 +9,8 @@ import org.jboss.arquillian.drone.webdriver.binary.downloading.Downloader;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.source.LocalBinarySource;
 import org.jboss.arquillian.drone.webdriver.binary.process.BinaryInteraction;
 import org.jboss.arquillian.drone.webdriver.utils.Constants;
+import org.jboss.arquillian.drone.webdriver.utils.PlatformUtils;
 import org.jboss.arquillian.drone.webdriver.utils.Validate;
-import org.jboss.arquillian.phantom.resolver.maven.PlatformUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -26,6 +18,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jboss.arquillian.drone.webdriver.utils.Constants.ARQUILLIAN_DRONE_CACHE_DIRECTORY;

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/PhantomJSDriverTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/PhantomJSDriverTestCase.java
@@ -1,0 +1,77 @@
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PhantomJSDriverTestCase {
+
+    @Test
+    public void testOpenSimplePage() throws IOException {
+        PhantomJSDriverFactory phantomJSDriverFactory = new PhantomJSDriverFactory();
+
+        DesiredCapabilities phantomJSCaps =
+            new DesiredCapabilities(new BrowserCapabilitiesList.PhantomJS().getRawCapabilities());
+        WebDriverConfiguration configuration = getMockedConfiguration(phantomJSCaps);
+
+        WebDriver driver = phantomJSDriverFactory.createInstance(configuration);
+        URL page = this.getClass().getClassLoader().getResource("simple.html");
+        driver.get(page.toString());
+        Assert.assertEquals("The page title doesn't match.", "Simple Page", driver.getTitle());
+        driver.quit();
+    }
+
+    @Test
+    public void testReformatCLIArgumentsInCapToArray() throws IOException {
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(outContent));
+
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, "--debug true");
+
+        PhantomJSDriverFactory phantomJSDriverFactory = new PhantomJSDriverFactory();
+        WebDriverConfiguration configuration = getMockedConfiguration(capabilities);
+
+        PhantomJSDriver instance = phantomJSDriverFactory.createInstance(configuration);
+        phantomJSDriverFactory.destroyInstance(instance);
+
+        assertThat(outContent.toString()).as("The log output should contain [DEBUG] string").contains("[DEBUG]");
+    }
+
+    @After
+    public void resetOutputStreams() {
+        System.setOut(System.out);
+        System.setErr(System.out);
+    }
+
+    private WebDriverConfiguration getMockedConfiguration(DesiredCapabilities capabilities) {
+        capabilities
+            .setCapability("phantomjsBinaryVersion", System.getProperty("default.supported.phantomjs.binary.version"));
+        WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
+
+        when(configuration.getCapabilities()).thenReturn(capabilities);
+        when(configuration.getImplementationClass())
+            .thenReturn(new BrowserCapabilitiesList.PhantomJS().getImplementationClassName());
+
+        return configuration;
+    }
+
+}

--- a/drone-webdriver/src/test/resources/arquillian.xml
+++ b/drone-webdriver/src/test/resources/arquillian.xml
@@ -5,6 +5,8 @@
         <!-- browser is set externally -->
         <property name="browser">${browser}</property>
 
+        <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
+
         <property name="seleniumServerVersion">${version.selenium}</property>
 
         <property name="dimensions">1300x500</property>
@@ -21,6 +23,8 @@
     <extension qualifier="webdriver-reusable">
         <!-- browser is set externally -->
         <property name="browser">${browser}</property>
+
+        <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
 
         <property name="seleniumServerVersion">${version.selenium}</property>
         <property name="remoteAddress">http://localhost:4444/wd/hub/</property>
@@ -40,6 +44,8 @@
     <extension qualifier="webdriver-reusecookies">
         <!-- browser is set externally -->
         <property name="browser">${browser}</property>
+
+        <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
 
         <property name="seleniumServerVersion">${version.selenium}</property>
         <property name="remoteAddress">http://localhost:4444/wd/hub/</property>

--- a/drone-webdriver/src/test/resources/hoverfly/gh.simulation.ariya@phantomjs.tags.json
+++ b/drone-webdriver/src/test/resources/hoverfly/gh.simulation.ariya@phantomjs.tags.json
@@ -1,0 +1,209 @@
+[
+  {
+    "name": "2.1.1",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/2.1.1",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/2.1.1",
+    "commit": {
+      "sha": "d9cda3dcd26b0e463533c5cc96e39c0f39fc32c1",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/d9cda3dcd26b0e463533c5cc96e39c0f39fc32c1"
+    }
+  },
+  {
+    "name": "2.1.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/2.1.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/2.1.0",
+    "commit": {
+      "sha": "292358499e1ac66503a2639a76aeb155aa44ef73",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/292358499e1ac66503a2639a76aeb155aa44ef73"
+    }
+  },
+  {
+    "name": "2.0.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/2.0.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/2.0.0",
+    "commit": {
+      "sha": "a2912c216d06df4d8b51f12ad4082a48c5fc7ba6",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/a2912c216d06df4d8b51f12ad4082a48c5fc7ba6"
+    }
+  },
+  {
+    "name": "1.9.8",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.8",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.8",
+    "commit": {
+      "sha": "41f9463d5a1f6f4d443d5234054d43387499130a",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/41f9463d5a1f6f4d443d5234054d43387499130a"
+    }
+  },
+  {
+    "name": "1.9.7",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.7",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.7",
+    "commit": {
+      "sha": "adaef213c010bae87811206f8d272a43d0ccd2b7",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/adaef213c010bae87811206f8d272a43d0ccd2b7"
+    }
+  },
+  {
+    "name": "1.9.6",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.6",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.6",
+    "commit": {
+      "sha": "0814bbfb6b6699fe713690f2566365e9d29a1c47",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/0814bbfb6b6699fe713690f2566365e9d29a1c47"
+    }
+  },
+  {
+    "name": "1.9.3",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.3",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.3",
+    "commit": {
+      "sha": "4ae580ce2c705d9ce099ca83b8e2274a176755ba",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/4ae580ce2c705d9ce099ca83b8e2274a176755ba"
+    }
+  },
+  {
+    "name": "1.9.2",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.2",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.2",
+    "commit": {
+      "sha": "3ff03acc2f835b12da6077434309350000ba5c03",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/3ff03acc2f835b12da6077434309350000ba5c03"
+    }
+  },
+  {
+    "name": "1.9.1",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.1",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.1",
+    "commit": {
+      "sha": "34c5e418f13d318168ddb2dc442a0687939d8c4f",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/34c5e418f13d318168ddb2dc442a0687939d8c4f"
+    }
+  },
+  {
+    "name": "1.9.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.9.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.9.0",
+    "commit": {
+      "sha": "da71c5fbddafbef5c033fd6cd4a916ab3c9fd548",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/da71c5fbddafbef5c033fd6cd4a916ab3c9fd548"
+    }
+  },
+  {
+    "name": "1.8.2",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.8.2",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.8.2",
+    "commit": {
+      "sha": "ea8a5b9a8d525919f4b0819ec12ab54e82f8e6a2",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/ea8a5b9a8d525919f4b0819ec12ab54e82f8e6a2"
+    }
+  },
+  {
+    "name": "1.8.1",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.8.1",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.8.1",
+    "commit": {
+      "sha": "98c3034b4bbeb9438d3e6b4d83436b150b0cb755",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/98c3034b4bbeb9438d3e6b4d83436b150b0cb755"
+    }
+  },
+  {
+    "name": "1.8.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.8.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.8.0",
+    "commit": {
+      "sha": "804ddfc9953c0caa6fc5d9d3b4dd3ab705359bfd",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/804ddfc9953c0caa6fc5d9d3b4dd3ab705359bfd"
+    }
+  },
+  {
+    "name": "1.7.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.7.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.7.0",
+    "commit": {
+      "sha": "cb441bcf3d0c95526bec0b824871c2070bcba6c5",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/cb441bcf3d0c95526bec0b824871c2070bcba6c5"
+    }
+  },
+  {
+    "name": "1.6.1",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.6.1",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.6.1",
+    "commit": {
+      "sha": "c856f13fec45676f4633b2a3bbeb955db1ff6bcd",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/c856f13fec45676f4633b2a3bbeb955db1ff6bcd"
+    }
+  },
+  {
+    "name": "1.6.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.6.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.6.0",
+    "commit": {
+      "sha": "e2295f805c0deeabcec4e3b28ba555bc9f3d29fa",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/e2295f805c0deeabcec4e3b28ba555bc9f3d29fa"
+    }
+  },
+  {
+    "name": "1.5.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.5.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.5.0",
+    "commit": {
+      "sha": "67a9e77770de27b91663c2ad0b0587123c90497c",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/67a9e77770de27b91663c2ad0b0587123c90497c"
+    }
+  },
+  {
+    "name": "1.4.1",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.4.1",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.4.1",
+    "commit": {
+      "sha": "5842899594f495fc81fe7e4c6a87d703ebf7c1c4",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/5842899594f495fc81fe7e4c6a87d703ebf7c1c4"
+    }
+  },
+  {
+    "name": "1.4.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.4.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.4.0",
+    "commit": {
+      "sha": "cbc9be0a7fdb354f81345b0eef1b1b7e840f0974",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/cbc9be0a7fdb354f81345b0eef1b1b7e840f0974"
+    }
+  },
+  {
+    "name": "1.3.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.3.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.3.0",
+    "commit": {
+      "sha": "11a5e952816d001fb228d51abc092a52af10ca57",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/11a5e952816d001fb228d51abc092a52af10ca57"
+    }
+  },
+  {
+    "name": "1.2.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.2.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.2.0",
+    "commit": {
+      "sha": "c8046c0c65166607cb04f5af9a1538bfc90965d6",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/c8046c0c65166607cb04f5af9a1538bfc90965d6"
+    }
+  },
+  {
+    "name": "1.1.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.1.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.1.0",
+    "commit": {
+      "sha": "717d9e93e7e7921c67ac4df5421bab4ec621e87e",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/717d9e93e7e7921c67ac4df5421bab4ec621e87e"
+    }
+  },
+  {
+    "name": "1.0.0",
+    "zipball_url": "https://api.github.com/repos/ariya/phantomjs/zipball/1.0.0",
+    "tarball_url": "https://api.github.com/repos/ariya/phantomjs/tarball/1.0.0",
+    "commit": {
+      "sha": "75506e37a5942b8dc3a1305977f20fe99c805a9f",
+      "url": "https://api.github.com/repos/ariya/phantomjs/commits/75506e37a5942b8dc3a1305977f20fe99c805a9f"
+    }
+  }
+]

--- a/drone-webdriver/src/test/resources/simple.html
+++ b/drone-webdriver/src/test/resources/simple.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>Simple Page</title>
+    </head>
+    <body>
+        <h1>Simple Page</h1>
+    </body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,12 @@
     <properties>
         <!-- Versioning -->
         <version.arquillian.core>1.1.12.Final</version.arquillian.core>
-        <version.phantom.driver>1.2.1.1</version.phantom.driver>
         <version.selenium>3.3.1</version.selenium>
         <version.htmlunit.driver>2.24</version.htmlunit.driver>
+        <phantomjs.driver.version>1.4.1</phantomjs.driver.version>
+
+        <!-- This is for tests purposes - to test with one specific PhantomJS version -->
+        <default.supported.phantomjs.binary.version>2.1.1</default.supported.phantomjs.binary.version>
 
         <!-- Test bits versions -->
         <version.junit>4.12</version.junit>


### PR DESCRIPTION
Drone doesn't rely on arquillian-phantom-* projects any more
PhantomJS is downloaded using Spacelift (the logic implemented in Drone and used for other binaries) from Bitbucket download storage
The latest version is retrieved from GH tags.