### PR TITLE
Failed to create nested cache folder

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/GitHubLastUpdateCache.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/GitHubLastUpdateCache.java
@@ -49,8 +49,8 @@ public class GitHubLastUpdateCache {
             throw new IllegalArgumentException(
                 "Passed [" + cacheDirectory.getAbsolutePath() + "] exists and is not a directory.");
         }
-        if (!cacheDirectory.exists()) {
-            cacheDirectory.mkdir();
+        if (!cacheDirectory.exists() && !cacheDirectory.mkdirs()) {
+            throw new RuntimeException("Could not create cache directory: " + cacheDirectory);
         }
         return cacheDirectory;
     }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/utils/GitHubLastUpdateCacheTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/utils/GitHubLastUpdateCacheTest.java
@@ -30,6 +30,18 @@ public class GitHubLastUpdateCacheTest {
     }
 
     @Test
+    public void should_create_nested_cache_folder() throws Exception {
+        // given
+        final File customCacheFolder = new File(new File(tmpFolder, "nested"), "custom-cache-folder");
+        gitHubLastUpdateCache = new GitHubLastUpdateCache(customCacheFolder);
+
+        // then
+        final SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(customCacheFolder).exists().isDirectory();
+        softly.assertAll();
+    }
+
+    @Test
     public void should_create_release_cache_folder() throws Exception {
         // given
         final File customCacheFolder = new File(tmpFolder, "custom-cache-folder");


### PR DESCRIPTION
#### Short description of what this resolves:

Creating the cache directory failed in case the parent folder did not exist. This lead to errors when storing assets down the road.