### PR TITLE
Adds webClient options to HtmlUnitDriver - ARQ-1836

### DIFF
--- a/docs/configuring-drone-instances.adoc
+++ b/docs/configuring-drone-instances.adoc
@@ -117,6 +117,12 @@ FirefoxDriver
 |Path to Firefox user preferences. This file will be parsed and values
 will be applied to freshly created Firefox profile.
 
+|htmlUnitWebClientOptions
+|-
+|Comma separated list of webClientOptions for HtmlUnitDriver. e.g.
+timeout=10,javaScriptEnabled=true, throwExceptionOnScriptError=false
+
+
 |dimensions
 |-
 |Dimensions of browser window in `widthxheight` format. This will resize

--- a/docs/configuring-drone-instances.adoc
+++ b/docs/configuring-drone-instances.adoc
@@ -119,8 +119,8 @@ will be applied to freshly created Firefox profile.
 
 |htmlUnitWebClientOptions
 |-
-|Comma separated list of webClientOptions for HtmlUnitDriver. e.g.
-timeout=10,javaScriptEnabled=true, throwExceptionOnScriptError=false
+|Semicolon separated list of webClientOptions for HtmlUnitDriver. e.g.
+timeout=10; javaScriptEnabled=true; throwExceptionOnScriptError=false; SSLClientProtocols=protocal1, protocal2
 
 
 |dimensions

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
@@ -93,7 +93,7 @@ public class BrowserCapabilitiesList {
 
         @Override
         public String getImplementationClassName() {
-            return "org.openqa.selenium.htmlunit.HtmlUnitDriver";
+            return "org.jboss.arquillian.drone.webdriver.htmlunit.HtmlUnitDriver";
         }
 
         @Override

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
@@ -37,8 +37,6 @@ public class BrowserCapabilitiesList {
         }
     }
 
-    ;
-
     public static class Edge implements BrowserCapabilities {
 
         @Override
@@ -61,8 +59,6 @@ public class BrowserCapabilitiesList {
             return 0;
         }
     }
-
-    ;
 
     public static class Firefox implements BrowserCapabilities {
 
@@ -87,13 +83,11 @@ public class BrowserCapabilitiesList {
         }
     }
 
-    ;
-
     public static class HtmlUnit implements BrowserCapabilities {
 
         @Override
         public String getImplementationClassName() {
-            return "org.jboss.arquillian.drone.webdriver.htmlunit.HtmlUnitDriver";
+            return "org.jboss.arquillian.drone.webdriver.htmlunit.DroneHtmlUnitDriver";
         }
 
         @Override
@@ -111,8 +105,6 @@ public class BrowserCapabilitiesList {
             return 0;
         }
     }
-
-    ;
 
     public static class InternetExplorer implements BrowserCapabilities {
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/htmlunit/DroneHtmlUnitDriver.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/htmlunit/DroneHtmlUnitDriver.java
@@ -2,16 +2,17 @@ package org.jboss.arquillian.drone.webdriver.htmlunit;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
-public class HtmlUnitDriver extends org.openqa.selenium.htmlunit.HtmlUnitDriver {
+public class DroneHtmlUnitDriver extends HtmlUnitDriver {
 
-    public HtmlUnitDriver(Capabilities capabilities) {
+    public DroneHtmlUnitDriver(Capabilities capabilities) {
         super(capabilities);
     }
 
     @Override
     public WebClient modifyWebClient(WebClient client) {
-        // set multiple options for webclient here as per requirement. Nothing here now.
+        // set multiple options for webclient here as per requirement in future.
 
         return client;
     }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/htmlunit/HtmlUnitDriver.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/htmlunit/HtmlUnitDriver.java
@@ -1,0 +1,23 @@
+package org.jboss.arquillian.drone.webdriver.htmlunit;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import org.openqa.selenium.Capabilities;
+
+public class HtmlUnitDriver extends org.openqa.selenium.htmlunit.HtmlUnitDriver {
+
+    public HtmlUnitDriver(Capabilities capabilities) {
+        super(capabilities);
+    }
+
+    @Override
+    public WebClient modifyWebClient(WebClient client) {
+        // set multiple options for webclient here as per requirement. Nothing here now.
+
+        return client;
+    }
+
+    @Override
+    public WebClient getWebClient() {
+        return super.getWebClient();
+    }
+}

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/impl/BrowserCapabilitiesRegistryImpl.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/impl/BrowserCapabilitiesRegistryImpl.java
@@ -43,9 +43,9 @@ public class BrowserCapabilitiesRegistryImpl implements BrowserCapabilitiesRegis
             return null;
         }
 
-        for (BrowserCapabilities browser : registry.values()) {
-            if (className.equals(browser.getImplementationClassName())) {
-                return browser;
+        for (BrowserCapabilities browserCapabilities : registry.values()) {
+            if (className.equals(browserCapabilities.getImplementationClassName())) {
+                return browserCapabilities;
             }
         }
 

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Constants.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Constants.java
@@ -29,7 +29,7 @@ public class Constants {
     public static final String FIREFOX_DRIVER = "org.openqa.selenium.firefox.FirefoxDriver";
     public static final String EDGE_DRIVER = "org.openqa.selenium.edge.EdgeDriver";
     public static final String CHROME_DRIVER = "org.openqa.selenium.chrome.ChromeDriver";
-    public static final String HTMLUNIT_DRIVER = "org.openqa.selenium.htmlunit.HtmlUnitDriver";
+    public static final String HTMLUNIT_DRIVER = "org.jboss.arquillian.drone.webdriver.htmlunit.DroneHtmlUnitDriver";
     public static final String IE_DRIVER = "org.openqa.selenium.ie.InternetExplorerDriver";
     public static final String WEB_DRIVER = "org.openqa.selenium.WebDriver";
     public static final String OPERA_DRIVER = "org.openqa.selenium.opera.OperaDriver";

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/HtmlUnitDriverTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/HtmlUnitDriverTest.java
@@ -1,0 +1,91 @@
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.MockWebConnection;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebClientOptions;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.jboss.arquillian.drone.webdriver.htmlunit.DroneHtmlUnitDriver;
+import org.jboss.arquillian.drone.webdriver.utils.Validate;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.arquillian.drone.webdriver.factory.HtmlUnitDriverFactory.webClientOptions;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HtmlUnitDriverTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldOverrideWebClientOptions() throws IOException {
+        final HtmlUnitDriverFactory htmlUnitDriverFactory = new HtmlUnitDriverFactory();
+        final WebDriverConfiguration configuration = getMockedConfiguration("ThrowExceptionOnFailingStatusCode=true");
+        final WebDriver driver = htmlUnitDriverFactory.createInstance(configuration);
+        final DroneHtmlUnitDriver htmlUnitDriver = (DroneHtmlUnitDriver) driver;
+
+        MockWebConnection webConnection = new MockWebConnection();
+        webConnection.setDefaultResponse("http://foo.com", 503, "Service Unavailable", "text/plain");
+
+        WebClient webClient = htmlUnitDriver.getWebClient();
+        webClient.setWebConnection(webConnection);
+
+        thrown.expect(WebDriverException.class);
+        thrown.expectMessage(
+            "com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException: 503 Service Unavailable for http://foo.com/");
+
+        driver.get("http://foo.com");
+        driver.quit();
+    }
+
+    @Test
+    public void shouldSetWebClientOptionsForHtmlUnitDriver() throws IOException {
+        final HtmlUnitDriverFactory htmlUnitDriverFactory = new HtmlUnitDriverFactory();
+        final WebDriverConfiguration configuration = getMockedConfiguration("Timeout=300; JavaScriptEnabled=false");
+        final WebDriver driver = htmlUnitDriverFactory.createInstance(configuration);
+        final DroneHtmlUnitDriver htmlUnitDriver = (DroneHtmlUnitDriver) driver;
+        final WebClient webClient = htmlUnitDriver.getWebClient();
+        final WebClientOptions webClientOptions = webClient.getOptions();
+
+        Assertions.assertThat(webClientOptions.isJavaScriptEnabled()).isFalse();
+        Assertions.assertThat(webClientOptions.getTimeout()).isEqualTo(300);
+    }
+
+    private WebDriverConfiguration getMockedConfiguration(String option) {
+
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        if (Validate.nonEmpty(option)) {
+            capabilities.setCapability(webClientOptions, option);
+        }
+        WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
+
+        when(configuration.getCapabilities()).thenReturn(capabilities);
+        when(configuration.getImplementationClass())
+            .thenReturn(new BrowserCapabilitiesList.HtmlUnit().getImplementationClassName());
+
+        return configuration;
+    }
+}
+

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/WebClientOptionsMapperTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/WebClientOptionsMapperTest.java
@@ -1,0 +1,34 @@
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import com.gargoylesoftware.htmlunit.WebClientOptions;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+public class WebClientOptionsMapperTest {
+
+    @Test
+    public void shouldSetWebClientOptions() {
+        //given
+        final String browserName = new BrowserCapabilitiesList.HtmlUnit().getReadableName();
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put(browserName + "Timeout", "10");
+        map.put(browserName + "JavaScriptEnabled", "false");
+        map.put(browserName + "ThrowExceptionOnScriptError", "false");
+
+        DesiredCapabilities capabilities = new DesiredCapabilities(map);
+        WebClientOptions webClientOptions = new WebClientOptions();
+
+        //when
+        CapabilitiesOptionsMapper.mapCapabilities(webClientOptions, capabilities,
+            browserName);
+
+        //then
+        Assertions.assertThat(webClientOptions.getTimeout()).isEqualTo(10);
+        Assertions.assertThat(webClientOptions.isJavaScriptEnabled()).isFalse();
+        Assertions.assertThat(webClientOptions.isThrowExceptionOnScriptError()).isFalse();
+    }
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestReusableRemoteWebDriver.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestReusableRemoteWebDriver.java
@@ -41,8 +41,9 @@ import static org.junit.Assert.fail;
 public class TestReusableRemoteWebDriver extends AbstractInBrowserTest {
 
     @BeforeClass
-    public static void skipIfEdgeBrowser() {
-        Assume.assumeFalse(System.getProperty("browser").equals("edge"));
+    public static void skipIfEdgeOrHtmlUnitBrowser() {
+        final String browser = System.getProperty("browser");
+        Assume.assumeFalse(browser.equals("edge") || browser.equals("htmlunit") || browser.equals("htmlUnit"));
     }
 
     @Test

--- a/drone-webdriver/src/test/resources/arquillian.xml
+++ b/drone-webdriver/src/test/resources/arquillian.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
-  xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
   <extension qualifier="webdriver">
     <!-- browser is set externally -->
     <property name="browser">${browser}</property>
-
+    <property name="htmlUnitWebClientOptions">Timeout=300; throwExceptionOnScriptError=false</property>
     <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
 
     <property name="seleniumServerVersion">${version.selenium}</property>


### PR DESCRIPTION
#### Short description of what this resolves:
You can add webClientOptions to HtmlUnitDriver.

#### Changes proposed in this pull request:

- Subclassed HtmlUnitDriver to override `protected modifyWebClient()`
- Used desired capabilities to set options from confiiguration to `WebClientOption` 


**Fixes**: #ARQ-1836
