### PR TITLE
ARQ-2112 As the last PhantomJS release is considered 2.1.1 so Drone won't check if there is any newer one

### DIFF
--- a/drone-webdriver/pom.xml
+++ b/drone-webdriver/pom.xml
@@ -205,13 +205,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <systemPropertyVariables>
-                <default.supported.phantomjs.binary.version>
-                  ${default.supported.phantomjs.binary.version}
-                </default.supported.phantomjs.binary.version>
-              </systemPropertyVariables>
-            </configuration>
             <executions>
               <execution>
                 <id>default-test</id>

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
@@ -1,7 +1,5 @@
 package org.jboss.arquillian.drone.webdriver.binary.downloading.source;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
 import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
 import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
@@ -20,32 +18,44 @@ public class PhantomJSGitHubBitbucketSource extends GitHubSource {
 
     private static String BASE_DOWNLOAD_URL = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-";
 
+    private static String lastPhantomJSRelease = "2.1.1";
+
     public PhantomJSGitHubBitbucketSource(HttpClient httpClient, GitHubLastUpdateCache gitHubLastUpdateCache) {
         super("ariya", "phantomjs", httpClient, gitHubLastUpdateCache);
     }
 
-    @Override
+    /**
+     * As there was announced the end of the development of PhantomJS:
+     * https://groups.google.com/forum/#!msg/phantomjs/9aI5d-LDuNE/5Z3SMZrqAQAJ
+     * it is not necessary to check the latest release - it is expected that there won't be any newer than the last
+     * one: 2.1.1
+     * If the development of PhantomJS is resurrected, then the logic will be uncommented.
+     */
     public ExternalBinary getLatestRelease() throws Exception {
+        // See the javadoc of this method for explanation why this code is commented out
 
-        final HttpClient.Response response =
-            sentGetRequestWithPagination(getProjectUrl() + TAGS_URL, 1, lastModificationHeader());
-        final ExternalBinary latestPhantomJSBinary;
+        //        final HttpClient.Response response =
+        //            sentGetRequestWithPagination(getProjectUrl() + TAGS_URL, 1, lastModificationHeader());
+        //        final ExternalBinary latestPhantomJSBinary;
+        //
+        //        if (response.hasPayload()) {
+        //            JsonArray releaseTags = getGson().fromJson(response.getPayload(), JsonElement.class).getAsJsonArray();
+        //            if (releaseTags.size() == 0) {
+        //                return null;
+        //            }
+        //            String version = releaseTags.get(0).getAsJsonObject().get(TAG_NAME).getAsString();
+        //            latestPhantomJSBinary = new ExternalBinary(version);
+        //
+        //            latestPhantomJSBinary.setUrl(getUrlForVersion(version));
+        //            getCache().store(latestPhantomJSBinary, getUniqueKey(), extractModificationDate(response));
+        //        } else {
+        //            latestPhantomJSBinary = getCache().load(getUniqueKey(), ExternalBinary.class);
+        //        }
 
-        if (response.hasPayload()) {
-            JsonArray releaseTags = getGson().fromJson(response.getPayload(), JsonElement.class).getAsJsonArray();
-            if (releaseTags.size() == 0) {
-                return null;
-            }
-            String version = releaseTags.get(0).getAsJsonObject().get(TAG_NAME).getAsString();
-            latestPhantomJSBinary = new ExternalBinary(version);
+        ExternalBinary lastPhantomJSVersion = new ExternalBinary(lastPhantomJSRelease);
+        lastPhantomJSVersion.setUrl(getUrlForVersion(lastPhantomJSRelease));
 
-            latestPhantomJSBinary.setUrl(getUrlForVersion(version));
-            getCache().store(latestPhantomJSBinary, getUniqueKey(), extractModificationDate(response));
-        } else {
-            latestPhantomJSBinary = getCache().load(getUniqueKey(), ExternalBinary.class);
-        }
-
-        return latestPhantomJSBinary;
+        return lastPhantomJSVersion;
     }
 
     @Override

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
@@ -27,7 +27,8 @@ public class PhantomJSGitHubBitbucketSource extends GitHubSource {
      * it is not necessary to check the latest release - it is expected that there won't be any newer than the last
      * one: 2.1.1
      * If the development of PhantomJS is resurrected, then the original logic will be brought back. In this case
-     * as a reference use this commit: 5f4f64146dfbb42b641464dfb89aaa811b008a31
+     * as a reference use this logic:
+     * https://github.com/arquillian/arquillian-extension-drone/blob/5f4f64146dfbb42b641464dfb89aaa811b008a31/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java#L30-L51
      * or The class that is currently used for testing purposes: GitHubSourceLatestReleaseFromTagsTestCase.PhantomJSSourceForLatestRelease
      */
     public ExternalBinary getLatestRelease() throws Exception {

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/PhantomJSGitHubBitbucketSource.java
@@ -13,9 +13,6 @@ import static org.jboss.arquillian.drone.webdriver.binary.handler.PhantomJSDrive
  */
 public class PhantomJSGitHubBitbucketSource extends GitHubSource {
 
-    private static String TAGS_URL = "/tags";
-    private static String TAG_NAME = "name";
-
     private static String BASE_DOWNLOAD_URL = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-";
 
     private static String lastPhantomJSRelease = "2.1.1";
@@ -29,28 +26,11 @@ public class PhantomJSGitHubBitbucketSource extends GitHubSource {
      * https://groups.google.com/forum/#!msg/phantomjs/9aI5d-LDuNE/5Z3SMZrqAQAJ
      * it is not necessary to check the latest release - it is expected that there won't be any newer than the last
      * one: 2.1.1
-     * If the development of PhantomJS is resurrected, then the logic will be uncommented.
+     * If the development of PhantomJS is resurrected, then the original logic will be brought back. In this case
+     * as a reference use this commit: 5f4f64146dfbb42b641464dfb89aaa811b008a31
+     * or The class that is currently used for testing purposes: GitHubSourceLatestReleaseFromTagsTestCase.PhantomJSSourceForLatestRelease
      */
     public ExternalBinary getLatestRelease() throws Exception {
-        // See the javadoc of this method for explanation why this code is commented out
-
-        //        final HttpClient.Response response =
-        //            sentGetRequestWithPagination(getProjectUrl() + TAGS_URL, 1, lastModificationHeader());
-        //        final ExternalBinary latestPhantomJSBinary;
-        //
-        //        if (response.hasPayload()) {
-        //            JsonArray releaseTags = getGson().fromJson(response.getPayload(), JsonElement.class).getAsJsonArray();
-        //            if (releaseTags.size() == 0) {
-        //                return null;
-        //            }
-        //            String version = releaseTags.get(0).getAsJsonObject().get(TAG_NAME).getAsString();
-        //            latestPhantomJSBinary = new ExternalBinary(version);
-        //
-        //            latestPhantomJSBinary.setUrl(getUrlForVersion(version));
-        //            getCache().store(latestPhantomJSBinary, getUniqueKey(), extractModificationDate(response));
-        //        } else {
-        //            latestPhantomJSBinary = getCache().load(getUniqueKey(), ExternalBinary.class);
-        //        }
 
         ExternalBinary lastPhantomJSVersion = new ExternalBinary(lastPhantomJSRelease);
         lastPhantomJSVersion.setUrl(getUrlForVersion(lastPhantomJSRelease));
@@ -65,7 +45,7 @@ public class PhantomJSGitHubBitbucketSource extends GitHubSource {
         return phantomJSBinary;
     }
 
-    private String getUrlForVersion(String version) {
+    protected String getUrlForVersion(String version) {
         StringBuilder phantomJsUrl = new StringBuilder(BASE_DOWNLOAD_URL);
         phantomJsUrl.append(version).append("-");
 

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseFromTagsTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseFromTagsTestCase.java
@@ -4,11 +4,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import io.specto.hoverfly.junit.dsl.ResponseBuilder;
 import io.specto.hoverfly.junit.rule.HoverflyRule;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.assertj.core.api.JUnitSoftAssertions;
@@ -17,9 +12,16 @@ import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
 import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 
 import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
@@ -30,6 +32,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@Ignore("For the evaluation the PhantomJSGitHubBitbucketSource is used. But it doesn't use this logic any more."
+    + "For more information see the javadoc of PhantomJSGitHubBitbucketSource#getLatestRelease")
 public class GitHubSourceLatestReleaseFromTagsTestCase {
 
     private static final String CACHED_CONTENT = "{\"lastModified\":\"Tue, 28 Mar 2017 05:23:15 GMT\"," +

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/PhantomJSDriverTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/PhantomJSDriverTestCase.java
@@ -1,9 +1,5 @@
 package org.jboss.arquillian.drone.webdriver.factory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.net.URL;
 import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
 import org.junit.After;
 import org.junit.Assert;
@@ -15,6 +11,11 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -62,8 +63,6 @@ public class PhantomJSDriverTestCase {
     }
 
     private WebDriverConfiguration getMockedConfiguration(DesiredCapabilities capabilities) {
-        capabilities
-            .setCapability("phantomjsBinaryVersion", System.getProperty("default.supported.phantomjs.binary.version"));
         WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
 
         when(configuration.getCapabilities()).thenReturn(capabilities);

--- a/drone-webdriver/src/test/resources/arquillian.xml
+++ b/drone-webdriver/src/test/resources/arquillian.xml
@@ -6,7 +6,6 @@
     <!-- browser is set externally -->
     <property name="browser">${browser}</property>
     <property name="htmlUnitWebClientOptions">Timeout=300; throwExceptionOnScriptError=false</property>
-    <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
 
     <property name="seleniumServerVersion">${version.selenium}</property>
 
@@ -24,8 +23,6 @@
   <extension qualifier="webdriver-reusable">
     <!-- browser is set externally -->
     <property name="browser">${browser}</property>
-
-    <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
 
     <property name="seleniumServerVersion">${version.selenium}</property>
     <property name="remoteAddress">http://localhost:4444/wd/hub/</property>
@@ -45,8 +42,6 @@
   <extension qualifier="webdriver-reusecookies">
     <!-- browser is set externally -->
     <property name="browser">${browser}</property>
-
-    <property name="phantomjsBinaryVersion">${default.supported.phantomjs.binary.version}</property>
 
     <property name="seleniumServerVersion">${version.selenium}</property>
     <property name="remoteAddress">http://localhost:4444/wd/hub/</property>

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,6 @@
     <version.htmlunit.driver>2.26</version.htmlunit.driver>
     <phantomjs.driver.version>1.4.1</phantomjs.driver.version>
 
-    <!-- This is for tests purposes - to test with one specific PhantomJS version -->
-    <default.supported.phantomjs.binary.version>2.1.1</default.supported.phantomjs.binary.version>
-
     <!-- Test bits versions -->
     <version.junit>4.12</version.junit>
     <version.assertj>3.6.2</version.assertj>


### PR DESCRIPTION
The reason is that there was announced the end of the development of PhantomJS:
https://groups.google.com/forum/#!msg/phantomjs/9aI5d-LDuNE/5Z3SMZrqAQAJ
so it is expected that there won't be any newer version than the last one: 2.1.1
