### PR TITLE
ARQ-2114 It was easy to reach the GH rate limit when firefox is used in large test suites running in CI

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
@@ -4,7 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.net.URI;
+import org.apache.http.client.utils.URIBuilder;
+import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
+import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
+import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
+import org.jboss.arquillian.drone.webdriver.utils.Rfc2126DateTimeFormatter;
+
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -12,11 +17,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
-import org.apache.http.client.utils.URIBuilder;
-import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
-import org.jboss.arquillian.drone.webdriver.utils.GitHubLastUpdateCache;
-import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
-import org.jboss.arquillian.drone.webdriver.utils.Rfc2126DateTimeFormatter;
 
 import static org.apache.http.HttpHeaders.IF_MODIFIED_SINCE;
 import static org.apache.http.HttpHeaders.LAST_MODIFIED;
@@ -159,8 +159,11 @@ public abstract class GitHubSource implements ExternalBinarySource {
 
     protected HttpClient.Response sentGetRequestWithPagination(String url, int pageNumber, Map<String, String> headers)
         throws Exception {
-        final URI uri = new URIBuilder(url).setParameter("page", String.valueOf(pageNumber)).build();
-        return httpClient.get(uri.toString(), headers);
+        final URIBuilder uriBuilder = new URIBuilder(url);
+        if (pageNumber != 1) {
+            uriBuilder.setParameter("page", String.valueOf(pageNumber));
+        }
+        return httpClient.get(uriBuilder.build().toString(), headers);
     }
 
     protected String getProjectUrl() {

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/HttpClient.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/HttpClient.java
@@ -1,9 +1,5 @@
 package org.jboss.arquillian.drone.webdriver.utils;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -12,7 +8,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
 public class HttpClient {
+
+    private final Logger log = Logger.getLogger(HttpClient.class.getName());
 
     public Response get(String url) throws IOException {
         return get(url, Collections.emptyMap());
@@ -22,6 +27,7 @@ public class HttpClient {
         try (CloseableHttpClient client = createHttpClient()) {
             final HttpGet request = new HttpGet(url);
             addHeaders(headers, request);
+            log.info("Sending request: " + request + " with headers: " + Arrays.asList(request.getAllHeaders()));
             final HttpResponse response = client.execute(request);
             return Response.from(response);
         }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/HttpClient.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/HttpClient.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class HttpClient {
@@ -27,7 +28,8 @@ public class HttpClient {
         try (CloseableHttpClient client = createHttpClient()) {
             final HttpGet request = new HttpGet(url);
             addHeaders(headers, request);
-            log.info("Sending request: " + request + " with headers: " + Arrays.asList(request.getAllHeaders()));
+            String message = "Sending request: " + request + " with headers: " + Arrays.asList(request.getAllHeaders());
+            log.log(PropertySecurityAction.isArquillianDebug() ? Level.INFO : Level.FINE, message);
             final HttpResponse response = client.execute(request);
             return Response.from(response);
         }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/PropertySecurityAction.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/PropertySecurityAction.java
@@ -79,4 +79,8 @@ public class PropertySecurityAction {
             }
         }
     }
+
+    public static boolean isArquillianDebug(){
+        return Boolean.valueOf(PropertySecurityAction.getProperty("arquillian.debug"));
+    }
 }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseFromTagsTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseFromTagsTestCase.java
@@ -73,7 +73,6 @@ public class GitHubSourceLatestReleaseFromTagsTestCase {
         // given
         hoverflyRule.simulate(dsl(service("https://api.github.com")
             .get("/repos/ariya/phantomjs/tags")
-            .queryParam("page", 1)
             .willReturn(
                 ResponseBuilder.response()
                     .header("Last-Modified", "Tue, 28 Mar 2017 05:23:15 GMT")
@@ -100,7 +99,6 @@ public class GitHubSourceLatestReleaseFromTagsTestCase {
         hoverflyRule.simulate(dsl(service("https://api.github.com")
             .get("/repos/ariya/phantomjs/tags")
             .header(HttpHeaders.IF_MODIFIED_SINCE, "Tue, 28 Mar 2017 05:23:15 GMT")
-            .queryParam("page", 1)
             .willReturn(
                 ResponseBuilder.response().status(HttpStatus.SC_NOT_MODIFIED)
             )));
@@ -137,7 +135,6 @@ public class GitHubSourceLatestReleaseFromTagsTestCase {
             .get("/repos/ariya/phantomjs/tags")
             .header(HttpHeaders.IF_MODIFIED_SINCE,
                 "Sun, 01 Jan 2017 17:16:07 GMT") // But we expect it to be sent in GMT, as this is how we match the request
-            .queryParam("page", 1)
             .willReturn(
                 ResponseBuilder.response()
                     .header("Last-Modified", "Tue, 28 Mar 2017 05:23:15 GMT")

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSourceLatestReleaseTestCase.java
@@ -4,11 +4,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import io.specto.hoverfly.junit.dsl.ResponseBuilder;
 import io.specto.hoverfly.junit.rule.HoverflyRule;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.assertj.core.api.JUnitSoftAssertions;
@@ -20,6 +15,12 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 
 import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
@@ -74,7 +75,6 @@ public class GitHubSourceLatestReleaseTestCase {
         // given
         hoverflyRule.simulate(dsl(service("https://api.github.com")
             .get("/repos/mozilla/geckodriver/releases/latest")
-            .queryParam("page", 1)
             .willReturn(
                 ResponseBuilder.response().header("Last-Modified", "Tue, 31 Jan 2017 17:16:07 GMT").body(RESPONSE_BODY)
             )));
@@ -99,7 +99,6 @@ public class GitHubSourceLatestReleaseTestCase {
         hoverflyRule.simulate(dsl(service("https://api.github.com")
             .get("/repos/mozilla/geckodriver/releases/latest")
             .header(HttpHeaders.IF_MODIFIED_SINCE, "Tue, 31 Jan 2017 17:16:07 GMT")
-            .queryParam("page", 1)
             .willReturn(
                 ResponseBuilder.response().status(HttpStatus.SC_NOT_MODIFIED)
             )));
@@ -140,7 +139,6 @@ public class GitHubSourceLatestReleaseTestCase {
             .get("/repos/mozilla/geckodriver/releases/latest")
             .header(HttpHeaders.IF_MODIFIED_SINCE,
                 "Sun, 01 Jan 2017 17:16:07 GMT") // But we expect it to be sent in GMT, as this is how we match the request
-            .queryParam("page", 1)
             .willReturn(
                 ResponseBuilder.response().header("Last-Modified", "Tue, 31 Jan 2017 17:16:07 GMT").body(RESPONSE_BODY)
             )));

--- a/drone-webdriver/src/test/resources/hoverfly/gh.simulation.mozilla@geckodriver.releases.json
+++ b/drone-webdriver/src/test/resources/hoverfly/gh.simulation.mozilla@geckodriver.releases.json
@@ -7,7 +7,6 @@
           "method": "GET",
           "destination": "api.github.com",
           "scheme": "https",
-          "query": "page=1",
           "body": "",
           "headers": {
             "Accept-Encoding": [


### PR DESCRIPTION
- When a request with the first page is sent, then the parameter is not added -the reason is that conditional requests don't seem to be supported for parametrized requests

- When GH release is retrieved for a version then it check for the presence every page separately (lazily)

- When version is used, check for previous downloads is performed before getting the download URL

- Added logging about sending requests