### PR TITLE
Adds chrome headless as Browser property for Drone 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ Once Selenium Server is running, you can run the tests by:
 [source,bash]
 mvn clean verify -Dbrowser=${browser}
 
-Where browser has the same value as browser property from _arquillian.xml_ you want to tests (e.g. firefox, chrome, phantomjs, internetExplorer, opera, edge, etc.)
+Where browser has the same value as browser property from _arquillian.xml_ you want to tests (e.g. firefox, chrome, phantomjs, internetExplorer, opera, edge, chromeHeadless etc.)
 
 TIP: VNC server instance can be used to let all the browsers pop out in separate display. Just prepend both commands with +DISPLAY=:${display.number}+
 

--- a/docs/configuring-drone-instances.adoc
+++ b/docs/configuring-drone-instances.adoc
@@ -69,18 +69,19 @@ WebDriver uses `webdriver` qualifier.
 
 |browser
 |htmlUnit
-|Determines which browser instance is created for WebDriver testing.
+a|Determines which browser instance is created for WebDriver testing.
 
 Following values are valid:
 
-. chrome +
-. firefox +
-. htmlUnit  or htmlunit +
-. internetExplorer or internetexplorer +
-. opera +
-. phantomjs +
-. safari +
-. edge +
+* chrome
+* chromeHeadless or chromeheadless
+* firefox
+* htmlUnit  or htmlunit
+* internetExplorer or internetexplorer
+* opera
+* phantomjs
+* safari
+* edge
 
 |iePort
 |-

--- a/drone-webdriver/pom.xml
+++ b/drone-webdriver/pom.xml
@@ -308,11 +308,11 @@
                       <property>browser</property>
                       <message>browser property must be specified!</message>
                       <regex>
-                        firefox|android|htmlUnit|htmlunit|safari|chrome|opera|phantomjs|iphone|internetExplorer|internetexplorer|edge
+                        firefox|android|htmlUnit|htmlunit|safari|chrome|opera|phantomjs|iphone|internetExplorer|internetexplorer|edge|chromeHeadless|chromeheadless
                       </regex>
                       <regexMessage>-Dbrowser must be one of: firefox, android, htmlUnit/htmlunit, safari, chrome,
                         opera,
-                        phantomjs, iphone, internetExplorer/internetexplorer, edge but was ${browser}
+                        phantomjs, iphone, internetExplorer/internetexplorer, edge, chromeHeadless/chromeheadless but was ${browser}
                       </regexMessage>
                     </requireProperty>
                   </rules>
@@ -406,6 +406,36 @@
 
       <properties>
         <browser>chrome</browser>
+        <selenium.chrome.driver>dummy</selenium.chrome.driver>
+      </properties>
+    </profile>
+    <profile>
+      <id>chromeheadless</id>
+
+      <activation>
+        <property>
+          <name>browser</name>
+          <value>chromeheadless</value>
+        </property>
+      </activation>
+
+      <properties>
+        <browser>chromeheadless</browser>
+        <selenium.chrome.driver>dummy</selenium.chrome.driver>
+      </properties>
+    </profile>
+    <profile>
+      <id>chromeHeadless</id>
+
+      <activation>
+        <property>
+          <name>browser</name>
+          <value>chromeHeadless</value>
+        </property>
+      </activation>
+
+      <properties>
+        <browser>chromeHeadless</browser>
         <selenium.chrome.driver>dummy</selenium.chrome.driver>
       </properties>
     </profile>

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/DroneWebDriverExtension.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/DroneWebDriverExtension.java
@@ -86,6 +86,7 @@ public class DroneWebDriverExtension implements LoadableExtension {
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.Remote.class);
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.Safari.class);
         builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.PhantomJS.class);
+        builder.service(BrowserCapabilities.class, BrowserCapabilitiesList.chromeHeadless.class);
 
         builder.observer(ReusableRemoteWebDriverExtension.class);
         builder.service(ReusedSessionPermanentStorage.class, ReusedSessionPermanentFileStorage.class);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerExecutor.java
@@ -114,6 +114,8 @@ public class SeleniumServerExecutor {
             return new InternetExplorerBinaryHandler(capabilities);
         } else if (new BrowserCapabilitiesList.PhantomJS().getReadableName().equals(browser)) {
             return new PhantomJSDriverBinaryHandler(capabilities);
+        } else if (new BrowserCapabilitiesList.chromeHeadless().getReadableName().equals(browser)) {
+            return new ChromeDriverBinaryHandler(capabilities);
         }
         return null;
     }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
@@ -225,7 +225,7 @@ public class BrowserCapabilitiesList {
     public static class chromeHeadless implements BrowserCapabilities {
         @Override
         public String getReadableName() {
-            return "chromeHeadless";
+            return "chromeheadless";
         }
 
         @Override

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/BrowserCapabilitiesList.java
@@ -130,8 +130,6 @@ public class BrowserCapabilitiesList {
         }
     }
 
-    ;
-
     public static class Opera implements BrowserCapabilities {
 
         @Override
@@ -154,8 +152,6 @@ public class BrowserCapabilitiesList {
             return 0;
         }
     }
-
-    ;
 
     public static class Remote implements BrowserCapabilities {
 
@@ -180,8 +176,6 @@ public class BrowserCapabilitiesList {
         }
     }
 
-    ;
-
     public static class Safari implements BrowserCapabilities {
 
         @Override
@@ -204,8 +198,6 @@ public class BrowserCapabilitiesList {
             return 0;
         }
     }
-
-    ;
 
     public static class PhantomJS implements BrowserCapabilities {
 
@@ -230,5 +222,25 @@ public class BrowserCapabilitiesList {
         }
     }
 
-    ;
+    public static class chromeHeadless implements BrowserCapabilities {
+        @Override
+        public String getReadableName() {
+            return "chromeHeadless";
+        }
+
+        @Override
+        public String getImplementationClassName() {
+            return "org.openqa.selenium.chrome.ChromeDriver";
+        }
+
+        @Override
+        public Map<String, ?> getRawCapabilities() {
+            return DesiredCapabilities.chrome().asMap();
+        }
+
+        @Override
+        public int getPrecedence() {
+            return 0;
+        }
+    }
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
@@ -114,7 +114,7 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
         return capabilities;
     }
 
-    public static void setChromeOptions(WebDriverConfiguration configuration, DesiredCapabilities capabilities) {
+    public void setChromeOptions(WebDriverConfiguration configuration, DesiredCapabilities capabilities) {
         ChromeOptions chromeOptions = new ChromeOptions();
 
         String browser = configuration.getBrowser().toLowerCase();

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
@@ -102,21 +102,30 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
 
         new ChromeDriverBinaryHandler(capabilities).checkAndSetBinary(performValidations);
 
-        ChromeOptions chromeOptions = new ChromeOptions();
-
-        String browser = configuration.getBrowser();
-        if (browser.equals("chromeHeadless") || browser.equals("chromeheadless")) {
-            chromeOptions.addArguments("--headless");
-        }
-
-        CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, capabilities, BROWSER_CAPABILITIES);
-
         // verify binary capabilities
         if (Validate.nonEmpty(binary)) {
             if (performValidations) {
                 Validate.isExecutable(binary, "Chrome binary must point to an executable file, " + binary);
             }
+        }
 
+        setChromeOptions(configuration, capabilities);
+
+        return capabilities;
+    }
+
+    public static void setChromeOptions(WebDriverConfiguration configuration, DesiredCapabilities capabilities) {
+        ChromeOptions chromeOptions = new ChromeOptions();
+
+        String browser = configuration.getBrowser().toLowerCase();
+        if (browser.equals("chromeheadless")) {
+            chromeOptions.addArguments("--headless");
+        }
+
+        CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, capabilities, BROWSER_CAPABILITIES);
+
+        String binary = (String) capabilities.getCapability("chrome.binary");
+        if (Validate.nonEmpty(binary)) {
             // ARQ-1823 - setting chrome binary path through ChromeOptions
             chromeOptions.setBinary(binary);
         }
@@ -136,8 +145,6 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
                 log.warning(e.getMessage());
             }
         }
-
-        return capabilities;
     }
 
     @Override

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
@@ -103,6 +103,12 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
         new ChromeDriverBinaryHandler(capabilities).checkAndSetBinary(performValidations);
 
         ChromeOptions chromeOptions = new ChromeOptions();
+
+        String browser = configuration.getBrowser();
+        if (browser.equals("chromeHeadless") || browser.equals("chromeheadless")) {
+            chromeOptions.addArguments("--headless");
+        }
+
         CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, capabilities, BROWSER_CAPABILITIES);
 
         // verify binary capabilities

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -43,7 +43,6 @@ import org.jboss.arquillian.drone.webdriver.utils.UrlUtils;
 import org.jboss.arquillian.drone.webdriver.utils.Validate;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
@@ -93,7 +92,7 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
 
         Validate.isValidUrl(remoteAddress, "Remote address must be a valid url, " + remoteAddress);
 
-        String browser = configuration.getBrowser();
+        String browser = configuration.getBrowser().toLowerCase();
         if (Validate.empty(browser)) {
             configuration.setBrowser(WebDriverConfiguration.DEFAULT_BROWSER_CAPABILITIES);
             log.log(Level.INFO, "Property \"browser\" was not specified, using default value of {0}",
@@ -104,8 +103,8 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
 
         // construct capabilities
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(getCapabilities(configuration, true));
-        if (browser.equals("chromeHeadless") || browser.equals("chromeheadless")) {
-            getChromeHeadlessCapabilities(configuration, desiredCapabilities);
+        if (browser.equals("chrome") || browser.equals("chromeheadless")) {
+            ChromeDriverFactory.setChromeOptions(configuration, desiredCapabilities);
         }
 
         if (!UrlUtils.isReachable(remoteAddress)) {
@@ -144,14 +143,6 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
         }
 
         return driver;
-    }
-
-    private void getChromeHeadlessCapabilities(WebDriverConfiguration configuration, DesiredCapabilities desiredCapabilities) {
-        ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
-        Capabilities capabilities = chromeDriverFactory.getCapabilities(configuration, true);
-        ChromeOptions chromeOptions = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
-        CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, desiredCapabilities, BROWSER_CAPABILITIES);
-        desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
     }
 
     private void downloadAndStartSeleniumServer(WebDriverConfiguration configuration, String browser,

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -43,6 +43,7 @@ import org.jboss.arquillian.drone.webdriver.utils.UrlUtils;
 import org.jboss.arquillian.drone.webdriver.utils.Validate;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
@@ -103,6 +104,9 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
 
         // construct capabilities
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(getCapabilities(configuration, true));
+        if (browser.equals("chromeHeadless") || browser.equals("chromeheadless")) {
+            getChromeHeadlessCapabilities(configuration, desiredCapabilities);
+        }
 
         if (!UrlUtils.isReachable(remoteAddress)) {
             if (UrlUtils.isLocalhost(remoteAddress)) {
@@ -140,6 +144,14 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
         }
 
         return driver;
+    }
+
+    private void getChromeHeadlessCapabilities(WebDriverConfiguration configuration, DesiredCapabilities desiredCapabilities) {
+        ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
+        Capabilities capabilities = chromeDriverFactory.getCapabilities(configuration, true);
+        ChromeOptions chromeOptions = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
+        CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, desiredCapabilities, BROWSER_CAPABILITIES);
+        desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
     }
 
     private void downloadAndStartSeleniumServer(WebDriverConfiguration configuration, String browser,

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/RemoteWebDriverFactory.java
@@ -104,7 +104,7 @@ public class RemoteWebDriverFactory extends AbstractWebDriverFactory<RemoteWebDr
         // construct capabilities
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(getCapabilities(configuration, true));
         if (browser.equals("chrome") || browser.equals("chromeheadless")) {
-            ChromeDriverFactory.setChromeOptions(configuration, desiredCapabilities);
+            new ChromeDriverFactory().setChromeOptions(configuration, desiredCapabilities);
         }
 
         if (!UrlUtils.isReachable(remoteAddress)) {

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/ChromeHeadlessDriverTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/ChromeHeadlessDriverTest.java
@@ -1,0 +1,69 @@
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import java.io.IOException;
+import java.net.URL;
+import org.assertj.core.api.Assertions;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChromeHeadlessDriverTest {
+
+    @BeforeClass
+    public static void executeOnlyIfChromeHeadlessBrowser() {
+        String browser = System.getProperty("browser");
+        Assume.assumeTrue(browser.equals("chromeHeadless") || browser.equals("chromeheadless"));
+    }
+
+    @Test
+    public void testOpenSimplePageUsingHeadlessChrome() throws IOException {
+        ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
+
+        DesiredCapabilities chromeCaps =
+            new DesiredCapabilities(new BrowserCapabilitiesList.chromeHeadless().getRawCapabilities());
+        WebDriverConfiguration configuration = getMockedConfiguration(chromeCaps);
+
+        WebDriver driver = chromeDriverFactory.createInstance(configuration);
+        URL page = this.getClass().getClassLoader().getResource("simple.html");
+        driver.get(page.toString());
+        Assert.assertEquals("The page title doesn't match.", "Simple Page", driver.getTitle());
+        driver.quit();
+    }
+
+    @Test
+    public void shouldSetChromeOptionsForHeadlessChromeHeadlessDriver() throws IOException {
+        ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
+
+        DesiredCapabilities chromeCaps =
+            new DesiredCapabilities(new BrowserCapabilitiesList.chromeHeadless().getRawCapabilities());
+        WebDriverConfiguration configuration = getMockedConfiguration(chromeCaps);
+
+        Capabilities capabilities = chromeDriverFactory.getCapabilities(configuration, true);
+        ChromeOptions chromeOptions = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
+
+        Assertions.assertThat(chromeOptions.toJson().toString()).contains("headless");
+    }
+
+    private WebDriverConfiguration getMockedConfiguration(DesiredCapabilities capabilities) {
+        WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
+
+        when(configuration.getCapabilities()).thenReturn(capabilities);
+        when(configuration.getBrowser()).thenReturn("chromeHeadless");
+        when(configuration.getImplementationClass())
+            .thenReturn(new BrowserCapabilitiesList.chromeHeadless().getImplementationClassName());
+
+        return configuration;
+    }
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/ChromeHeadlessDriverTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/ChromeHeadlessDriverTest.java
@@ -2,18 +2,15 @@ package org.jboss.arquillian.drone.webdriver.factory;
 
 import java.io.IOException;
 import java.net.URL;
-import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static org.mockito.Mockito.when;
@@ -21,11 +18,14 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ChromeHeadlessDriverTest {
 
-    @Test
-    public void testOpenSimplePageIfUsingChromeHeadlessBrowser() throws IOException {
+    @BeforeClass
+    public static void executeOnlyIfChromeHeadlessBrowser() {
         String browser = System.getProperty("browser").toLowerCase();
         Assume.assumeTrue(browser.equals("chromeheadless"));
+    }
 
+    @Test
+    public void testOpenSimplePageUsingChromeHeadlessBrowser() throws IOException {
         ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
 
         DesiredCapabilities chromeCaps =
@@ -37,24 +37,6 @@ public class ChromeHeadlessDriverTest {
         driver.get(page.toString());
         Assert.assertEquals("The page title doesn't match.", "Simple Page", driver.getTitle());
         driver.quit();
-    }
-
-    @Test
-    public void shouldSetChromeOptionsForChromeHeadlessDriver() throws IOException {
-        ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
-
-        DesiredCapabilities chromeCaps =
-            new DesiredCapabilities(new BrowserCapabilitiesList.chromeHeadless().getRawCapabilities());
-        WebDriverConfiguration configuration = getMockedConfiguration(chromeCaps);
-
-        ChromeDriver driver = chromeDriverFactory.createInstance(configuration);
-        String browser = driver.getCapabilities().getBrowserName();
-
-        Capabilities capabilities = chromeDriverFactory.getCapabilities(configuration, true);
-        ChromeOptions chromeOptions = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
-
-        Assertions.assertThat(browser).isEqualTo("chrome");
-        Assertions.assertThat(chromeOptions.toJson().toString()).contains("headless");
     }
 
     private WebDriverConfiguration getMockedConfiguration(DesiredCapabilities capabilities) {

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/ChromeHeadlessDriverTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/ChromeHeadlessDriverTest.java
@@ -6,13 +6,13 @@ import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -21,14 +21,11 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ChromeHeadlessDriverTest {
 
-    @BeforeClass
-    public static void executeOnlyIfChromeHeadlessBrowser() {
-        String browser = System.getProperty("browser");
-        Assume.assumeTrue(browser.equals("chromeHeadless") || browser.equals("chromeheadless"));
-    }
-
     @Test
-    public void testOpenSimplePageUsingHeadlessChrome() throws IOException {
+    public void testOpenSimplePageIfUsingChromeHeadlessBrowser() throws IOException {
+        String browser = System.getProperty("browser").toLowerCase();
+        Assume.assumeTrue(browser.equals("chromeheadless"));
+
         ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
 
         DesiredCapabilities chromeCaps =
@@ -43,16 +40,20 @@ public class ChromeHeadlessDriverTest {
     }
 
     @Test
-    public void shouldSetChromeOptionsForHeadlessChromeHeadlessDriver() throws IOException {
+    public void shouldSetChromeOptionsForChromeHeadlessDriver() throws IOException {
         ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
 
         DesiredCapabilities chromeCaps =
             new DesiredCapabilities(new BrowserCapabilitiesList.chromeHeadless().getRawCapabilities());
         WebDriverConfiguration configuration = getMockedConfiguration(chromeCaps);
 
+        ChromeDriver driver = chromeDriverFactory.createInstance(configuration);
+        String browser = driver.getCapabilities().getBrowserName();
+
         Capabilities capabilities = chromeDriverFactory.getCapabilities(configuration, true);
         ChromeOptions chromeOptions = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
 
+        Assertions.assertThat(browser).isEqualTo("chrome");
         Assertions.assertThat(chromeOptions.toJson().toString()).contains("headless");
     }
 
@@ -60,10 +61,9 @@ public class ChromeHeadlessDriverTest {
         WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
 
         when(configuration.getCapabilities()).thenReturn(capabilities);
-        when(configuration.getBrowser()).thenReturn("chromeHeadless");
+        when(configuration.getBrowser()).thenReturn("chromeheadless");
         when(configuration.getImplementationClass())
             .thenReturn(new BrowserCapabilitiesList.chromeHeadless().getImplementationClassName());
-
         return configuration;
     }
 }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/HeadlessBrowserChromeOptionsTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/HeadlessBrowserChromeOptionsTest.java
@@ -1,0 +1,37 @@
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import java.io.IOException;
+import org.assertj.core.api.Assertions;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import static org.mockito.Mockito.when;
+
+public class HeadlessBrowserChromeOptionsTest {
+
+    @Test
+    public void shouldSetChromeOptionsForChromeHeadlessDriver() throws IOException {
+        ChromeDriverFactory chromeDriverFactory = new ChromeDriverFactory();
+
+        DesiredCapabilities chromeCaps =
+            new DesiredCapabilities(new BrowserCapabilitiesList.chromeHeadless().getRawCapabilities());
+        WebDriverConfiguration configuration = getMockedConfiguration(chromeCaps);
+
+        Capabilities capabilities = chromeDriverFactory.getCapabilities(configuration, true);
+        ChromeOptions chromeOptions = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
+
+        Assertions.assertThat(chromeOptions.toJson().toString()).contains("headless");
+    }
+
+    private WebDriverConfiguration getMockedConfiguration(DesiredCapabilities capabilities) {
+        WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
+
+        when(configuration.getCapabilities()).thenReturn(capabilities);
+        when(configuration.getBrowser()).thenReturn("chromeheadless");
+        return configuration;
+    }
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/MockBrowserCapabilitiesRegistry.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/MockBrowserCapabilitiesRegistry.java
@@ -37,6 +37,8 @@ public class MockBrowserCapabilitiesRegistry implements BrowserCapabilitiesRegis
             registerBrowserCapabilitiesFor(browser, new BrowserCapabilitiesList.Opera());
         } else if ("safari".equals(browser)) {
             registerBrowserCapabilitiesFor(browser, new BrowserCapabilitiesList.Safari());
+        } else if ("chromeHeadless".equals(browser) || "chromeheadless".equals(browser)) {
+            registerBrowserCapabilitiesFor(browser, new BrowserCapabilitiesList.chromeHeadless());
         } else {
             Assert.fail("MockBrowserCapabilitiesRegistry does not implement " + browser);
         }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
@@ -108,10 +108,10 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
 
         initializationParameter = new InitializationParameter(hubUrl, desiredCapabilities);
 
-        String browser = System.getProperty("browser", "phantomjs").toLowerCase();
+        String browser = System.getProperty("browser").toLowerCase();
         if (browser.equals("chromeheadless")) {
             when(configuration.getBrowser()).thenReturn("chromeheadless");
-            ChromeDriverFactory.setChromeOptions(configuration, (DesiredCapabilities) desiredCapabilities);
+            new ChromeDriverFactory().setChromeOptions(configuration, (DesiredCapabilities) desiredCapabilities);
         }
 
         when(configuration.getBrowser()).thenReturn("xyz");

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
@@ -32,6 +32,7 @@ import org.jboss.arquillian.drone.webdriver.binary.handler.SeleniumServerBinaryH
 import org.jboss.arquillian.drone.webdriver.binary.process.SeleniumServerExecutor;
 import org.jboss.arquillian.drone.webdriver.binary.process.StartSeleniumServer;
 import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory;
 import org.jboss.arquillian.drone.webdriver.factory.RemoteWebDriverFactory;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
@@ -75,9 +76,8 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
     private InitializationParameter initializationParameter;
 
     @BeforeClass
-    public static void skipIfEdgeOrChromeHeadlessBrowser() {
-        String browser = System.getProperty("browser", "phantomjs");
-        Assume.assumeFalse(browser.equals("edge") || browser.equals("chromeHeadless") || browser.equals("chromeheadless"));
+    public static void skipIfEdgeBrowser() {
+        Assume.assumeFalse(System.getProperty("browser", "phantomjs").equals("edge"));
     }
 
     @Override
@@ -107,6 +107,12 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
         runSeleniumServer();
 
         initializationParameter = new InitializationParameter(hubUrl, desiredCapabilities);
+
+        String browser = System.getProperty("browser", "phantomjs").toLowerCase();
+        if (browser.equals("chromeheadless")) {
+            when(configuration.getBrowser()).thenReturn("chromeheadless");
+            ChromeDriverFactory.setChromeOptions(configuration, (DesiredCapabilities) desiredCapabilities);
+        }
 
         when(configuration.getBrowser()).thenReturn("xyz");
         when(configuration.isRemoteReusable()).thenReturn(true);

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/TestRemoteWebDriverFactorySessionStoring.java
@@ -75,8 +75,9 @@ public class TestRemoteWebDriverFactorySessionStoring extends AbstractTestTestBa
     private InitializationParameter initializationParameter;
 
     @BeforeClass
-    public static void skipIfEdgeBrowser() {
-        Assume.assumeFalse(System.getProperty("browser", "phantomjs").equals("edge"));
+    public static void skipIfEdgeOrChromeHeadlessBrowser() {
+        String browser = System.getProperty("browser", "phantomjs");
+        Assume.assumeFalse(browser.equals("edge") || browser.equals("chromeHeadless") || browser.equals("chromeheadless"));
     }
 
     @Override


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, the only way to use headless chromium is to use chrome as a browser and then add 
`--headless` as a `chromeArguments` property:
```
<property name="browser">chrome</property>
<property name="chromeArguments">--headless</property>
```
The idea of this task is making it simpler - just using chromeHeadless as a browser property:
```
<property name="browser">chromeHeadless</property>
```
#### Changes proposed in this pull request:

- Adds support for chrome headless browser as a browser property.
- Adds test to verify ChromeHeadlessDriver for a simple loginPage.



**Fixes**: #91
