### PR TITLE
ARQ-2119 Introduced system property for skippping Drone creation/injection

### DIFF
--- a/docs/configuring-drone-instances.adoc
+++ b/docs/configuring-drone-instances.adoc
@@ -218,3 +218,7 @@ performed.
 
 Then System property are applied in the same fashion.
 
+== Skipping creation of @Drone instances
+
+In case you want to skip a creation/injection of `@Drone` instances you can use a system property `arquillian.drone.skip.creation` with a value `true`. This property is checked in a phase `@Before` so you can modify the property during the test execution.
+

--- a/docs/configuring-drone-instances.adoc
+++ b/docs/configuring-drone-instances.adoc
@@ -220,5 +220,5 @@ Then System property are applied in the same fashion.
 
 == Skipping creation of @Drone instances
 
-In case you want to skip a creation/injection of `@Drone` instances you can use a system property `arquillian.drone.skip.creation` with a value `true`. This property is checked in a phase `@Before` so you can modify the property during the test execution.
+In case you want to skip a creation/injection of `@Drone` instances you can use a system property `arquillian.drone.skip.creation` with a value `true`. This property is checked in a `@Before` phase, so you can modify the property during the test execution.
 

--- a/drone-impl/pom.xml
+++ b/drone-impl/pom.xml
@@ -105,11 +105,16 @@
       <artifactId>arquillian-config-impl-base</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${version.mockito}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>${version.system.rules}</version>
       <scope>test</scope>
     </dependency>
 

--- a/drone-impl/src/test/java/org/jboss/arquillian/drone/impl/EnricherTestCase.java
+++ b/drone-impl/src/test/java/org/jboss/arquillian/drone/impl/EnricherTestCase.java
@@ -49,6 +49,7 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -81,6 +82,9 @@ public class EnricherTestCase extends AbstractTestTestBase {
     @Mock
     private ServiceLoader serviceLoader;
 
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
     @Override
     protected void addExtensions(List<Class<?>> extensions) {
         extensions.add(DroneLifecycleManager.class);
@@ -111,11 +115,6 @@ public class EnricherTestCase extends AbstractTestTestBase {
         // These two stubbings are used in DeploymentTestCase -> hence Silent runner
         Mockito.when(deploymentDescription1.getName()).thenReturn(AnnotationMocks.DEPLOYMENT_1);
         Mockito.when(deploymentDescription2.getName()).thenReturn(AnnotationMocks.DEPLOYMENT_2);
-    }
-
-    @org.junit.After
-    public void resetProperty(){
-        System.clearProperty(ARQUILLIAN_DRONE_CREATION_PROPERTY);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <version.junit>4.12</version.junit>
     <version.assertj>3.6.2</version.assertj>
     <version.mockito>2.3.11</version.mockito>
+    <version.system.rules>1.16.1</version.system.rules>
 
     <!-- To avoid collisions with Jetty version we are using the same as packaged in Selenium Server -->
     <version.org.eclipse.jetty>9.4.3.v20170317</version.org.eclipse.jetty>


### PR DESCRIPTION
The property is `arquillian.drone.skip.creation`. When it is set to `true` then a Drone instance is not created and injected.
This property is checked in a phase `@Before` so it is possible to modify the property during the test execution.
Fix for issue #93 