### PR TITLE
Sets window-size as chrome-option for chrome headless mode.

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.drone.webdriver.factory;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.drone.spi.Configurator;
 import org.jboss.arquillian.drone.spi.Destructor;
@@ -31,6 +32,8 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import static org.jboss.arquillian.drone.webdriver.window.WindowResizer.DIMENSIONS_PATTERN;
 
 /**
  * Factory which combines {@link org.jboss.arquillian.drone.spi.Configurator},
@@ -120,6 +123,17 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
         String browser = configuration.getBrowser().toLowerCase();
         if (browser.equals("chromeheadless")) {
             chromeOptions.addArguments("--headless");
+            if (configuration.getDimensions() != null) {
+                String dimensions = configuration.getDimensions().toLowerCase().trim();
+                Matcher m = DIMENSIONS_PATTERN.matcher(dimensions);
+                if (m.matches()) {
+                    String width = m.group(1);
+                    String height = m.group(2);
+                    chromeOptions.addArguments(String.format("--window-size=%s,%s", width, height));
+                } else if (dimensions.equals("full") || dimensions.equals("fullscreen") || dimensions.equals("max")) {
+                    chromeOptions.addArguments("--window-size=1920,1080"); // workaround till a better way is found.
+                }
+            }
         }
 
         CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, capabilities, BROWSER_CAPABILITIES);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/window/Dimensions.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/window/Dimensions.java
@@ -1,0 +1,60 @@
+package org.jboss.arquillian.drone.webdriver.window;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+
+public class Dimensions {
+
+    public static final Pattern DIMENSIONS_PATTERN = Pattern.compile("([0-9]+)x([0-9]+)");
+
+    private String dimensions;
+    private int width;
+    private int height;
+
+    public Dimensions(WebDriverConfiguration configuration) {
+        this.dimensions = getDimensions(configuration);
+        if (dimensions != null) {
+            setDimensions(dimensions);
+        }
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public boolean hasFullscreenEnabled() {
+        if (dimensions != null) {
+            if (dimensions.equals("full") || dimensions.equals("fullscreen") || dimensions.equals("max")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String getDimensions(WebDriverConfiguration configuration) {
+        String dimensions = null;
+        if (configuration.getDimensions() != null) {
+            dimensions = configuration.getDimensions().toLowerCase().trim();
+        }
+        return dimensions;
+    }
+
+    private void setDimensions(String dimensions) {
+        Matcher m = DIMENSIONS_PATTERN.matcher(dimensions);
+        if (m.matches()) {
+            width = Integer.valueOf(m.group(1));
+            height = Integer.valueOf(m.group(2));
+        } else if (hasFullscreenEnabled()) {
+            width = 1366;
+            height = 768;
+        }
+    }
+}
+
+
+

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/window/WindowResizer.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/window/WindowResizer.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.arquillian.drone.webdriver.window;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
@@ -29,11 +31,6 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Support for resizing WebDriver windows to value defined in capabilities via {@code dimensions}.
  *
@@ -41,8 +38,8 @@ import java.util.regex.Pattern;
  */
 public class WindowResizer {
 
-    public static final Pattern DIMENSIONS_PATTERN = Pattern.compile("([0-9]+)x([0-9]+)");
     private static final Logger log = Logger.getLogger(WindowResizer.class.getName());
+
     @Inject
     Instance<DroneContext> droneContext;
 
@@ -71,18 +68,12 @@ public class WindowResizer {
         Validate.stateNotNull(configuration, "WebDriver configuration must not be null");
 
         String browser = configuration.getBrowser().toLowerCase();
-        if(!browser.equals("chromeheadless")) {
-            if (configuration.getDimensions() != null) {
-                String dimensions = configuration.getDimensions().toLowerCase().trim();
-                Matcher m = DIMENSIONS_PATTERN.matcher(dimensions);
-
-                if (m.matches()) {
-                    int width = Integer.valueOf(m.group(1));
-                    int height = Integer.valueOf(m.group(2));
-                    safelyResizeWindow(driver, width, height, dronePoint);
-                } else if (dimensions.equals("full") || dimensions.equals("fullscreen") || dimensions.equals("max")) {
-                    safelyMaximizeWindow(driver, dronePoint);
-                }
+        if (!browser.equals("chromeheadless")) {
+            Dimensions dimensions = new Dimensions(configuration);
+            if (dimensions.hasFullscreenEnabled()) {
+                safelyMaximizeWindow(driver, dronePoint);
+            } else {
+                safelyResizeWindow(driver, dimensions.getWidth(), dimensions.getHeight(), dronePoint);
             }
         }
     }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/window/WindowResizer.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/window/WindowResizer.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
  */
 public class WindowResizer {
 
-    static final Pattern DIMENSIONS_PATTERN = Pattern.compile("([0-9]+)x([0-9]+)");
+    public static final Pattern DIMENSIONS_PATTERN = Pattern.compile("([0-9]+)x([0-9]+)");
     private static final Logger log = Logger.getLogger(WindowResizer.class.getName());
     @Inject
     Instance<DroneContext> droneContext;
@@ -70,17 +70,19 @@ public class WindowResizer {
         WebDriverConfiguration configuration = context.get(dronePoint).getConfigurationAs(WebDriverConfiguration.class);
         Validate.stateNotNull(configuration, "WebDriver configuration must not be null");
 
-        if (configuration.getDimensions() != null) {
-            String dimensions = configuration.getDimensions().toLowerCase().trim();
-            Matcher m = DIMENSIONS_PATTERN.matcher(dimensions);
+        String browser = configuration.getBrowser().toLowerCase();
+        if(!browser.equals("chromeheadless")) {
+            if (configuration.getDimensions() != null) {
+                String dimensions = configuration.getDimensions().toLowerCase().trim();
+                Matcher m = DIMENSIONS_PATTERN.matcher(dimensions);
 
-            if (m.matches()) {
-                int width = Integer.valueOf(m.group(1));
-                int height = Integer.valueOf(m.group(2));
-                safelyResizeWindow(driver, width, height, dronePoint);
-
-            } else if (dimensions.equals("full") || dimensions.equals("fullscreen") || dimensions.equals("max")) {
-                safelyMaximizeWindow(driver, dronePoint);
+                if (m.matches()) {
+                    int width = Integer.valueOf(m.group(1));
+                    int height = Integer.valueOf(m.group(2));
+                    safelyResizeWindow(driver, width, height, dronePoint);
+                } else if (dimensions.equals("full") || dimensions.equals("fullscreen") || dimensions.equals("max")) {
+                    safelyMaximizeWindow(driver, dronePoint);
+                }
             }
         }
     }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/window/DimensionsPatternTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/window/DimensionsPatternTest.java
@@ -16,23 +16,42 @@
  */
 package org.jboss.arquillian.drone.webdriver.window;
 
-import java.util.regex.Matcher;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
 
 public class DimensionsPatternTest {
 
     @Test
     public void validSample() {
-        Matcher m = WindowResizer.DIMENSIONS_PATTERN.matcher("100x200");
-        Assert.assertTrue(m.matches());
-        Assert.assertEquals("100", m.group(1));
-        Assert.assertEquals("200", m.group(2));
+        WebDriverConfiguration mockedConfiguration = getMockedConfiguration("100x200");
+        Dimensions dimensions = new Dimensions(mockedConfiguration);
+        Assert.assertEquals(100, dimensions.getWidth());
+        Assert.assertEquals(200, dimensions.getHeight());
     }
 
     @Test
     public void invalidSample() {
-        Matcher m = WindowResizer.DIMENSIONS_PATTERN.matcher("100,200");
-        Assert.assertFalse(m.matches());
+        WebDriverConfiguration mockedConfiguration = getMockedConfiguration("100,200");
+        Dimensions dimensions = new Dimensions(mockedConfiguration);
+        Assert.assertEquals(0, dimensions.getWidth());
+        Assert.assertEquals(0, dimensions.getHeight());
+    }
+
+    @Test
+    public void validSampleWithFullscreen() {
+        WebDriverConfiguration mockedConfiguration = getMockedConfiguration("fullscreen");
+        Dimensions dimensions = new Dimensions(mockedConfiguration);
+        Assert.assertEquals(1366, dimensions.getWidth());
+        Assert.assertEquals(768, dimensions.getHeight());
+    }
+
+    private WebDriverConfiguration getMockedConfiguration(String dimension) {
+        WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
+        when(configuration.getDimensions()).thenReturn(dimension);
+        return configuration;
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
- Some websites and pages are broken if loaded in a browser window that is half the total screen size of the monitor. Resizing chrome is buggy in latest chrome-drivers and explicitly setting the window size when browser is opened is required.
- Improves the execution speed for Drone Test Suite when using `chromeHeadless` browser, by eliminating waiting time for window resizing. 

#### Changes proposed in this pull request:

- Set window size as argument via chromeOptions.

**Fixes**: #
