### PR TITLE
ARQ-2038 Create Drone extension for Appium

### DIFF
--- a/drone-bom/pom.xml
+++ b/drone-bom/pom.xml
@@ -93,6 +93,11 @@
         <artifactId>arquillian-drone-browserstack-extension</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-drone-appium-extension</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Selenium BOM -->
       <dependency>

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
@@ -56,7 +56,7 @@ public class CapabilitiesOptionsMapper {
      * @param browserPrefix
      *     A prefix the should the mapped parameters should start with
      */
-    static void mapCapabilities(Object object, DesiredCapabilities capabilities, String browserPrefix) {
+    public static void mapCapabilities(Object object, DesiredCapabilities capabilities, String browserPrefix) {
 
         Method[] methods = object.getClass().getMethods();
         List<String> processedMethods = new ArrayList<String>();

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
@@ -43,7 +43,7 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
 
     private static final Logger log = Logger.getLogger(ChromeDriverFactory.class.getName());
 
-    private static final String BROWSER_CAPABILITIES = new BrowserCapabilitiesList.Chrome().getReadableName();
+    public static final String BROWSER_CAPABILITIES = new BrowserCapabilitiesList.Chrome().getReadableName();
     private static final String CHROME_PRINT_OPTIONS = "chromePrintOptions";
 
     /*

--- a/extension/arquillian-drone-appium-extension/README.adoc
+++ b/extension/arquillian-drone-appium-extension/README.adoc
@@ -1,0 +1,120 @@
+= Arquillian Drone Appium extension
+
+This is an Arquillian extension that enables you to use the Appium project with Drone and Graphene in your functional tests for mobile devices.
+
+NOTE: This extension only provides the integration of Appium WebDrivers with Drone, i.e. it only instantiates an Appium Driver and passes `DesiredCapabilities` to it. +
+For more instructions on how to install and configure Appium server and mobile physical and/or virtual devices please refer to: +
+https://github.com/appium/appium +
+https://github.com/appium/java-client +
+http://appium.io/ +
+
+=== How to use it
+
+1):: First of all, you need to have this extension on your project's classpath. Eg. as a Maven dependency:
+[source,xml]
+----
+    <dependency>
+        <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-drone-appium-extension</artifactId>
+        <version>${version.org.jboss.arquillian.drone}</version>
+    </dependency>
+----
+NOTE: Please keep in mind that this dependency doesn't serve as a dependency chain - you also need to add the dependencies mentioned in http://arquillian.org/arquillian-extension-drone/#_getting_started
+
+2):: To use an Appium Driver you need to specify `appium` as a `browser` property:
+[source,xml]
+----
+    <extension qualifier="webdriver">
+        <property name="browser">appium</property>
+        ...
+    </extension>
+----
+
+3):: You then need to specify the Desired Capabilities for the Appium server. Some of them are required given the specific platform. E.g.:
+[source,xml]
+----
+    <extension qualifier="webdriver">
+        <property name="browser">appium</property>
+        <property name="platformName">android</property>
+        <property name="deviceName">Some Android emulator</property>
+        <property name="browserName">chrome</property>
+        <property name="avd">nexus</property>
+    </extension>
+----
+For more info please see the complete list of supported capabilities: https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md
+
+==== Using remote Appium server
+
+By default, Appium Driver starts the local Appium server by itself (or if running already, it connects to it.
+To override this, you can also specify a remote address where is Appium server listening:
+[source,xml]
+----
+    <extension qualifier="webdriver">
+        ...
+        <property name="remoteAddress">http://192.168.1.12:4723/wd/hub</property>
+        ...
+    </extension>
+----
+
+==== ChromeOptions
+
+In case of Android and Google Chrome browser, you can also specify `ChromeOptions` the same way as with the standard ChromeDriver (using the 'chrome' prefix). E.g.
+[source,xml]
+----
+    <extension qualifier="webdriver">
+        ...
+        <property name="chromeArguments">--disable-translate</property>
+        ...
+    </extension>
+----
+
+==== Instantiation timeout
+
+Since a mobile virtual device boot is typically performed when instantiating the driver, the `instantiationTimeoutInSeconds` is set to 240 seconds (instead of the default 60) by this extension. +
+To override this you can simply use e.g.
+[source,xml]
+----
+    <extension qualifier="drone">
+        <property name="instantiationTimeoutInSeconds">120</property>
+    </extension>
+----
+
+==== Appium Driver implementations
+
+Different driver implementations are instantiated by this extension based on the desired platform:
+
+* http://appium.github.io/java-client/io/appium/java_client/android/AndroidDriver.html[AndroidDriver]
+* http://appium.github.io/java-client/io/appium/java_client/ios/IOSDriver.html[IOSDriver]
+* http://appium.github.io/java-client/io/appium/java_client/windows/WindowsDriver.html[WindowsDriver]
+* Generic http://appium.github.io/java-client/io/appium/java_client/AppiumDriver.html[AppiumDriver]
+
+You can then type cast the driver object to a specific one, e.g.:
+[source,java]
+----
+    AndroidDriver androidDriver = (AndroidDriver) driver;
+    androidDriver.openNotifications();
+----
+
+==== Using different Appium Java Client version
+
+Since the Appium development is much more rapid that this extension, you can of course use a newer `java-client` version (and therefore newer Appium Driver) in your project.
+You can e.g. just exclude the `java-client` dependency from this extension and use your desired version:
+[source,xml]
+----
+    <dependency>
+        <groupId>io.appium</groupId>
+        <artifactId>java-client</artifactId>
+        <version>5.0.0-BETA9</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-drone-appium-extension</artifactId>
+        <version>${version.org.jboss.arquillian.drone}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>io.appium</groupId>
+                <artifactId>java-client</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+----

--- a/extension/arquillian-drone-appium-extension/README.adoc
+++ b/extension/arquillian-drone-appium-extension/README.adoc
@@ -45,7 +45,7 @@ For more info please see the complete list of supported capabilities: https://gi
 
 ==== Using remote Appium server
 
-By default, Appium Driver starts the local Appium server by itself (or if running already, it connects to it.
+By default, Appium Driver starts the local Appium server by itself (or if running already), it connects to it.
 To override this, you can also specify a remote address where is Appium server listening:
 [source,xml]
 ----

--- a/extension/arquillian-drone-appium-extension/pom.xml
+++ b/extension/arquillian-drone-appium-extension/pom.xml
@@ -48,12 +48,7 @@
     <dependency>
       <groupId>io.appium</groupId>
       <artifactId>java-client</artifactId>
-      <version>5.0.0-BETA9</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.6</version>
+      <version>${version.appium.java.client}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/extension/arquillian-drone-appium-extension/pom.xml
+++ b/extension/arquillian-drone-appium-extension/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2017, Red Hat Middleware LLC, and individual contributors
+  ~ by the @authors tag. See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~ <p>
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-drone-build</artifactId>
+    <groupId>org.jboss.arquillian.extension</groupId>
+    <version>2.2.1-SNAPSHOT</version>
+    <relativePath>../../drone-build/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-drone-appium-extension</artifactId>
+  <name>Arquillian Drone Appium Extension</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-drone-webdriver</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-drone-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-remote-driver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.appium</groupId>
+      <artifactId>java-client</artifactId>
+      <version>5.0.0-BETA9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.6</version>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+      <version>${version.mockito}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.core</groupId>
+      <artifactId>arquillian-core-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-impl-base</artifactId>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.core</groupId>
+      <artifactId>arquillian-core-impl-base</artifactId>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/AppiumExtension.java
+++ b/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/AppiumExtension.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.drone.appium.extension;
+
+import org.arquillian.drone.appium.extension.webdriver.AppiumCapabilities;
+import org.arquillian.drone.appium.extension.webdriver.AppiumDriverFactory;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.drone.spi.Configurator;
+import org.jboss.arquillian.drone.spi.Destructor;
+import org.jboss.arquillian.drone.spi.Instantiator;
+import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class AppiumExtension implements LoadableExtension {
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(BrowserCapabilities.class, AppiumCapabilities.class);
+
+        extensionBuilder.service(Configurator.class, AppiumDriverFactory.class);
+        extensionBuilder.service(Instantiator.class, AppiumDriverFactory.class);
+        extensionBuilder.service(Destructor.class, AppiumDriverFactory.class);
+
+        extensionBuilder.observer(DefaultValuesModifier.class);
+    }
+}

--- a/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/DefaultValuesModifier.java
+++ b/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/DefaultValuesModifier.java
@@ -45,9 +45,11 @@ public class DefaultValuesModifier {
      */
     public void modifyDefaultTimeout(@Observes(precedence = -100) BeforeSuite event) {
         if (arquillianDescriptor.get()
-            .extension("drone")
+            .extension(GlobalDroneConfiguration.CONFIGURATION_NAME)
             .getExtensionProperties()
-            .get("instantiationTimeoutInSeconds") != null) return;
+            .get("instantiationTimeoutInSeconds") != null) {
+            return;
+        }
 
         GlobalDroneConfiguration globalDroneConfiguration =
             droneContext.get().getGlobalDroneConfiguration(GlobalDroneConfiguration.class);

--- a/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/DefaultValuesModifier.java
+++ b/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/DefaultValuesModifier.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.drone.appium.extension;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.drone.impl.DroneLifecycleManager.GlobalDroneConfiguration;
+import org.jboss.arquillian.drone.spi.DroneContext;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+
+/**
+ * Modifies default WebDriver/Drone properties
+ *
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class DefaultValuesModifier {
+    public static final int DEFAULT_INSTANTIATION_TIMEOUT = 240;
+
+    @Inject
+    private Instance<DroneContext> droneContext;
+
+    @Inject
+    private Instance<ArquillianDescriptor> arquillianDescriptor;
+
+    /**
+     * Sets the default instantiationTimeoutInSeconds Drone property
+     * @param event
+     */
+    public void modifyDefaultTimeout(@Observes(precedence = -100) BeforeSuite event) {
+        if (arquillianDescriptor.get()
+            .extension("drone")
+            .getExtensionProperties()
+            .get("instantiationTimeoutInSeconds") != null) return;
+
+        GlobalDroneConfiguration globalDroneConfiguration =
+            droneContext.get().getGlobalDroneConfiguration(GlobalDroneConfiguration.class);
+        globalDroneConfiguration.setInstantiationTimeoutInSeconds(DEFAULT_INSTANTIATION_TIMEOUT);
+    }
+}

--- a/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/webdriver/AppiumCapabilities.java
+++ b/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/webdriver/AppiumCapabilities.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.drone.appium.extension.webdriver;
+
+import io.appium.java_client.AppiumDriver;
+import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.Map;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class AppiumCapabilities implements BrowserCapabilities {
+    public static final String READABLE_NAME = "appium";
+
+    @Override
+    public String getImplementationClassName() {
+        return AppiumDriver.class.getName();
+    }
+
+    @Override
+    public Map<String, ?> getRawCapabilities() {
+        return new DesiredCapabilities().asMap();
+    }
+
+    @Override
+    public String getReadableName() {
+        return READABLE_NAME;
+    }
+
+    @Override
+    public int getPrecedence() {
+        return 0;
+    }
+}

--- a/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/webdriver/AppiumDriverFactory.java
+++ b/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/webdriver/AppiumDriverFactory.java
@@ -25,7 +25,6 @@ import io.appium.java_client.remote.MobileBrowserType;
 import io.appium.java_client.remote.MobileCapabilityType;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.windows.WindowsDriver;
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -38,6 +37,7 @@ import org.jboss.arquillian.drone.webdriver.factory.CapabilitiesOptionsMapper;
 import org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory;
 import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
 import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilitiesRegistry;
+import org.jboss.arquillian.drone.webdriver.utils.Validate;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -89,23 +89,33 @@ public class AppiumDriverFactory implements
         Capabilities capabilities = getCapabilities(configuration);
 
         String platform = (String)capabilities.getCapability(MobileCapabilityType.PLATFORM_NAME);
-        if (StringUtils.isBlank(platform)) {
+        if (Validate.empty(platform)) {
             throw new IllegalArgumentException("You have to specify " + MobileCapabilityType.PLATFORM_NAME);
         }
         platform = platform.toLowerCase();
 
         Class<? extends AppiumDriver> driverClass;
-             if (MobilePlatform.ANDROID.toLowerCase().equals(platform)) driverClass = AndroidDriver.class;
-        else if (MobilePlatform.IOS.toLowerCase().equals(platform))     driverClass = IOSDriver.class;
-        else if (MobilePlatform.WINDOWS.toLowerCase().equals(platform)) driverClass = WindowsDriver.class;
-        else                                                            driverClass = AppiumDriver.class;
+        if (MobilePlatform.ANDROID.toLowerCase().equals(platform)) {
+            driverClass = AndroidDriver.class;
+        }
+        else if (MobilePlatform.IOS.toLowerCase().equals(platform)) {
+            driverClass = IOSDriver.class;
+        }
+        else if (MobilePlatform.WINDOWS.toLowerCase().equals(platform)) {
+            driverClass = WindowsDriver.class;
+        }
+        else {
+            driverClass = AppiumDriver.class;
+        }
 
         URL remoteAddress = configuration.getRemoteAddress();
         try {
-            if (remoteAddress == null)
+            if (remoteAddress == null) {
                 return driverClass.getConstructor(Capabilities.class).newInstance(capabilities);
-            else
+            }
+            else {
                 return driverClass.getConstructor(URL.class, Capabilities.class).newInstance(remoteAddress, capabilities);
+            }
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/webdriver/AppiumDriverFactory.java
+++ b/extension/arquillian-drone-appium-extension/src/main/java/org/arquillian/drone/appium/extension/webdriver/AppiumDriverFactory.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.drone.appium.extension.webdriver;
+
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.remote.AndroidMobileCapabilityType;
+import io.appium.java_client.remote.MobileBrowserType;
+import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.remote.MobilePlatform;
+import io.appium.java_client.windows.WindowsDriver;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.spi.Configurator;
+import org.jboss.arquillian.drone.spi.Destructor;
+import org.jboss.arquillian.drone.spi.DronePoint;
+import org.jboss.arquillian.drone.spi.Instantiator;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.jboss.arquillian.drone.webdriver.factory.CapabilitiesOptionsMapper;
+import org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory;
+import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
+import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilitiesRegistry;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.net.URL;
+
+import static org.arquillian.drone.appium.extension.webdriver.AppiumCapabilities.READABLE_NAME;
+
+/**
+ * Factory which combines {@link org.jboss.arquillian.drone.spi.Configurator},
+ * {@link org.jboss.arquillian.drone.spi.Instantiator} and {@link org.jboss.arquillian.drone.spi.Destructor} for
+ * Appium Java Client.
+ *
+ * @see <a href="https://github.com/appium/java-client">https://github.com/appium/java-client</a>
+ * @see <a href="https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md">https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md</a>
+ *  for supported capabilities
+ *
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class AppiumDriverFactory implements
+    Configurator<AppiumDriver, WebDriverConfiguration>,
+    Instantiator<AppiumDriver, WebDriverConfiguration>,
+    Destructor<AppiumDriver> {
+
+    @Inject
+    private Instance<BrowserCapabilitiesRegistry> registryInstance;
+
+    @Override
+    public void destroyInstance(AppiumDriver instance) {
+        instance.quit();
+    }
+
+    @Override
+    public int getPrecedence() {
+        return 0;
+    }
+
+    /**
+     * Creates {@link AndroidDriver}, {@link IOSDriver}, {@link WindowsDriver} or generic {@link AppiumDriver}
+     * based on {@value MobileCapabilityType#PLATFORM_NAME} in Arquillian descriptor.
+     *
+     * @param configuration
+     *     the configuration object for the extension
+     *
+     * @return The Appium WebDriver
+     */
+    @Override
+    public AppiumDriver createInstance(WebDriverConfiguration configuration) {
+        Capabilities capabilities = getCapabilities(configuration);
+
+        String platform = (String)capabilities.getCapability(MobileCapabilityType.PLATFORM_NAME);
+        if (StringUtils.isBlank(platform)) {
+            throw new IllegalArgumentException("You have to specify " + MobileCapabilityType.PLATFORM_NAME);
+        }
+        platform = platform.toLowerCase();
+
+        Class<? extends AppiumDriver> driverClass;
+             if (MobilePlatform.ANDROID.toLowerCase().equals(platform)) driverClass = AndroidDriver.class;
+        else if (MobilePlatform.IOS.toLowerCase().equals(platform))     driverClass = IOSDriver.class;
+        else if (MobilePlatform.WINDOWS.toLowerCase().equals(platform)) driverClass = WindowsDriver.class;
+        else                                                            driverClass = AppiumDriver.class;
+
+        URL remoteAddress = configuration.getRemoteAddress();
+        try {
+            if (remoteAddress == null)
+                return driverClass.getConstructor(Capabilities.class).newInstance(capabilities);
+            else
+                return driverClass.getConstructor(URL.class, Capabilities.class).newInstance(remoteAddress, capabilities);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Creates {@link Capabilities} instance with Chrome options set in case of Android and Chrome browser
+     *
+     * @param configuration
+     * @return {@link Capabilities} instance
+     */
+    public Capabilities getCapabilities(WebDriverConfiguration configuration) {
+        DesiredCapabilities capabilities = new DesiredCapabilities(configuration.getCapabilities());
+
+        String browser = (String)capabilities.getCapability(MobileCapabilityType.BROWSER_NAME);
+        if (browser != null) browser = browser.toLowerCase();
+
+        // Set chromeOptions
+        if (MobileBrowserType.CHROME.toLowerCase().equals(browser)) {
+            ChromeOptions chromeOptions = new ChromeOptions();
+            CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, capabilities, ChromeDriverFactory.BROWSER_CAPABILITIES);
+            capabilities.setCapability(AndroidMobileCapabilityType.CHROME_OPTIONS, chromeOptions);
+        }
+
+        return capabilities;
+    }
+
+    @Override
+    public WebDriverConfiguration createConfiguration(ArquillianDescriptor descriptor, DronePoint<AppiumDriver> dronePoint) {
+        BrowserCapabilities browser = registryInstance.get().getEntryFor(READABLE_NAME);
+        return new WebDriverConfiguration(browser).configure(descriptor, dronePoint.getQualifier());
+    }
+}

--- a/extension/arquillian-drone-appium-extension/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/extension/arquillian-drone-appium-extension/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.arquillian.drone.appium.extension.AppiumExtension

--- a/extension/arquillian-drone-appium-extension/src/test/java/org/arquillian/drone/appium/extension/DroneDefaultValuesTest.java
+++ b/extension/arquillian-drone-appium-extension/src/test/java/org/arquillian/drone/appium/extension/DroneDefaultValuesTest.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.drone.appium.extension;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.core.spi.context.ApplicationContext;
+import org.jboss.arquillian.drone.impl.DroneLifecycleManager;
+import org.jboss.arquillian.drone.impl.DroneRegistrar;
+import org.jboss.arquillian.drone.spi.DroneContext;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+import org.jboss.arquillian.test.test.AbstractTestTestBase;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+/**
+ * @see org.jboss.arquillian.drone.impl.GlobalDroneConfigurationTestCase
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DroneDefaultValuesTest extends AbstractTestTestBase {
+    @Mock
+    private ServiceLoader serviceLoader;
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        extensions.add(DroneLifecycleManager.class);
+        extensions.add(DroneRegistrar.class);
+        extensions.add(DefaultValuesModifier.class);
+    }
+
+    @Test
+    public void defaultConfiguration() throws Exception {
+        // given
+        ArquillianDescriptor descriptor = Descriptors.create(ArquillianDescriptor.class);
+
+        getManager().bind(ApplicationScoped.class, ServiceLoader.class, serviceLoader);
+        getManager().bind(ApplicationScoped.class, ArquillianDescriptor.class, descriptor);
+
+        // then
+        verifyTimeout(DefaultValuesModifier.DEFAULT_INSTANTIATION_TIMEOUT);
+    }
+
+    @Test
+    public void specificConfiguration() throws Exception {
+        // given
+        ArquillianDescriptor descriptor = Descriptors.create(ArquillianDescriptor.class)
+            .extension("drone").property("instantiationTimeoutInSeconds", "40");
+
+        getManager().bind(ApplicationScoped.class, ServiceLoader.class, serviceLoader);
+        getManager().bind(ApplicationScoped.class, ArquillianDescriptor.class, descriptor);
+
+        // then
+        verifyTimeout(40);
+    }
+
+    private void verifyTimeout(int timeout) {
+        // when
+        getManager().fire(new BeforeSuite());
+
+        DroneContext context = getManager().getContext(ApplicationContext.class).getObjectStore().get(DroneContext
+            .class);
+        Assert.assertNotNull("DroneContext was created in the context", context);
+
+        DroneLifecycleManager.GlobalDroneConfiguration globalDroneConfiguration = context.getGlobalDroneConfiguration
+            (DroneLifecycleManager.GlobalDroneConfiguration.class);
+        Assert.assertNotNull("Global Drone configuration was created", globalDroneConfiguration);
+        Assert.assertEquals("Drone timeout is set to " + timeout + " seconds", timeout,
+            globalDroneConfiguration.getInstantiationTimeoutInSeconds());
+    }
+}

--- a/extension/arquillian-drone-appium-extension/src/test/java/org/arquillian/drone/appium/extension/webdriver/AppiumDriverFactoryTest.java
+++ b/extension/arquillian-drone-appium-extension/src/test/java/org/arquillian/drone/appium/extension/webdriver/AppiumDriverFactoryTest.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.arquillian.drone.appium.extension.webdriver;
+
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AppiumDriverFactoryTest {
+    private static final String PLATFORM_NAME = "platformName";
+    private static final String BROWSER_NAME = "browserName";
+    private static final String CHROME_OPTIONS_VALUE = "--disable-translate";
+
+    @Test
+    public void testCapabilities() throws IOException {
+        DesiredCapabilities originalCapabilities = new DesiredCapabilities();
+        originalCapabilities.setCapability(PLATFORM_NAME, "android");
+        originalCapabilities.setCapability(BROWSER_NAME, "chrome");
+        originalCapabilities.setCapability("chromeArguments", CHROME_OPTIONS_VALUE);
+
+        AppiumDriverFactory factory = new AppiumDriverFactory();
+
+        Capabilities newCapabilities = factory.getCapabilities(getMockedConfiguration(originalCapabilities));
+
+        assertEquals(originalCapabilities.getCapability(PLATFORM_NAME), newCapabilities.getCapability(PLATFORM_NAME));
+        assertEquals(originalCapabilities.getCapability(BROWSER_NAME), newCapabilities.getCapability(BROWSER_NAME));
+
+        ChromeOptions chromeOptions = (ChromeOptions)newCapabilities.getCapability(ChromeOptions.CAPABILITY);
+        assertTrue(chromeOptions.toJson().toString().contains(CHROME_OPTIONS_VALUE));
+    }
+
+    private WebDriverConfiguration getMockedConfiguration(DesiredCapabilities capabilities) {
+        WebDriverConfiguration configuration = Mockito.mock(WebDriverConfiguration.class);
+
+        when(configuration.getCapabilities()).thenReturn(capabilities);
+
+        return configuration;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
     <!-- Drone extensions -->
     <module>extension/arquillian-drone-saucelabs-extension</module>
     <module>extension/arquillian-drone-browserstack-extension</module>
+    <module>extension/arquillian-drone-appium-extension</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <version.selenium>3.4.0</version.selenium>
     <version.htmlunit.driver>2.26</version.htmlunit.driver>
     <phantomjs.driver.version>1.4.1</phantomjs.driver.version>
+    <version.appium.java.client>5.0.0-BETA9</version.appium.java.client>
 
     <!-- Test bits versions -->
     <version.junit>4.12</version.junit>


### PR DESCRIPTION
#### Short description of what this resolves:
Adds the extension for Appium.
https://issues.jboss.org/browse/ARQ-2038

#### Changes proposed in this pull request:

- Adds the extension
- Allows mapping `ChromeOptions` from outside the package (i.e. to allow the extension to use the mapping mechanics)

**Fixes**: #

With regards to tests. Since full integration tests would require specifically configured environment with Appium server, some mobile virtual device etc., I've created just some unit-like tests.

However, I wasn't sure how to properly test the `instantiationTimeoutInSeconds`, so I "took inspiration" (i.e. basically copied [GlobalDroneConfigurationTestCase](https://github.com/arquillian/arquillian-extension-drone/blob/master/drone-impl/src/test/java/org/jboss/arquillian/drone/impl/GlobalDroneConfigurationTestCase.java)).
Please let me know if it's ok - if not, I'll try to write it differently.