### PR TITLE
ARQ-2132 Support for FirefoxOptions and SafariOptions

### DIFF
--- a/docs/configuring-drone-instances.adoc
+++ b/docs/configuring-drone-instances.adoc
@@ -215,6 +215,18 @@ If you struggle with passing required chrome options through the `arquillian.xml
 ```
 This ensures that Drone prints out the whole content of `ChromeOptions` in a JSON format to the standard output.
 
+=== Options for other drivers
+Similarly to Chrome options, you can also configure https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/firefox/FirefoxOptions.html[FirefoxOptions], https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/safari/SafariOptions.html[SafariOptions] and https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/opera/OperaOptions.html[OperaOptions] classes for Firefox, Safari and Opera, respectively.
+
+For example, to set GeckoDriver logger level, use:
+```xml
+<property name=“firefoxLogLevel”>SEVERE</property>
+```
+
+Or to use Safari Technology Preview, specify:
+```xml
+<property name=“safariUseTechnologyPreview”>false</property>
+```
 
 [[graphene-2-configuration]]
 === Graphene 2 Configuration

--- a/drone-configuration/src/main/java/org/jboss/arquillian/drone/configuration/ConfigurationMapper.java
+++ b/drone-configuration/src/main/java/org/jboss/arquillian/drone/configuration/ConfigurationMapper.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.drone.configuration.mapping.BooleanValueMapper;
 import org.jboss.arquillian.drone.configuration.mapping.DoubleValueMapper;
 import org.jboss.arquillian.drone.configuration.mapping.FileValueMapper;
 import org.jboss.arquillian.drone.configuration.mapping.IntegerValueMapper;
+import org.jboss.arquillian.drone.configuration.mapping.LogLevelMapper;
 import org.jboss.arquillian.drone.configuration.mapping.LongValueMapper;
 import org.jboss.arquillian.drone.configuration.mapping.StringValueMapper;
 import org.jboss.arquillian.drone.configuration.mapping.URIValueMapper;
@@ -68,6 +69,7 @@ public class ConfigurationMapper {
         VALUE_MAPPERS.add(URIValueMapper.INSTANCE);
         VALUE_MAPPERS.add(URLValueMapper.INSTANCE);
         VALUE_MAPPERS.add(FileValueMapper.INSTANCE);
+        VALUE_MAPPERS.add(LogLevelMapper.INSTANCE);
     }
 
     // FIXME this should not be a static helper class but a proper observer on ArquillianDescriptor

--- a/drone-configuration/src/main/java/org/jboss/arquillian/drone/configuration/mapping/LogLevelMapper.java
+++ b/drone-configuration/src/main/java/org/jboss/arquillian/drone/configuration/mapping/LogLevelMapper.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.drone.configuration.mapping;
+
+import java.util.logging.Level;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public enum LogLevelMapper implements ValueMapper<Level> {
+
+    INSTANCE;
+
+    @Override
+    public boolean handles(Class<?> type, Class<?>... parameters) {
+        return Level.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Level transform(String value) throws IllegalArgumentException {
+        return Level.parse(value);
+    }
+}

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
@@ -182,7 +182,8 @@ public class CapabilitiesOptionsMapper {
     }
 
     private static boolean isSetter(Method candidate) {
-        return candidate.getName().matches("^(set|add)[A-Z].*") && candidate.getReturnType().equals(Void.TYPE)
+        return candidate.getName().matches("^(set|add)[A-Z].*")
+            && (candidate.getReturnType().equals(Void.TYPE) || candidate.getReturnType().equals(candidate.getDeclaringClass()))
             && candidate.getParameterTypes().length > 0;
     }
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/SafariDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/SafariDriverFactory.java
@@ -21,7 +21,9 @@ import org.jboss.arquillian.drone.spi.Destructor;
 import org.jboss.arquillian.drone.spi.Instantiator;
 import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariOptions;
 
 /**
  * Factory which combines {@link org.jboss.arquillian.drone.spi.Configurator},
@@ -68,7 +70,14 @@ public class SafariDriverFactory extends AbstractWebDriverFactory<SafariDriver> 
      * @return A {@link Capabilities} instance
      */
     public Capabilities getCapabilities(WebDriverConfiguration configuration, boolean performValidations) {
-        return configuration.getCapabilities();
+        DesiredCapabilities capabilities = new DesiredCapabilities(configuration.getCapabilities());
+
+        SafariOptions safariOptions = new SafariOptions();
+        CapabilitiesOptionsMapper.mapCapabilities(safariOptions, capabilities, BROWSER_CAPABILITIES);
+
+        capabilities.setCapability(SafariOptions.CAPABILITY, safariOptions);
+
+        return capabilities;
     }
 
     @Override


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Adds support for FirefoxOptions and SafariOptions.

#### Changes proposed in this pull request:
- Adds support for FirefoxOptions and SafariOptions in the factories.
- Changes a bit the behavior of Firefox capabilities / creating a new profile. The main change is that explicit new profile is created only when necessary. Please see the inline comments for details.
- Adds LogLevelMapper for setting the logLevel in FirefoxOptions.