### PR TITLE
ARQ-2140 Support for specifying the architecture for IE driver binary

### DIFF
--- a/docs/automatic-download.adoc
+++ b/docs/automatic-download.adoc
@@ -50,6 +50,8 @@ _Url driver property_ - use this arquillian.xml property to define an URL the bi
 
 _Cache subdirectory_ - name of the sub-directory (withing `$HOME/.arquillian/drone/`) the binaries are cached in
 
+_Architecture_ - in arquillian.xml file, you can explicitly specify the target architecture of the binary for selected webdrivers; if not specified it's then resolved from the host OS
+
 ===== Selenium Server
 |===
 
@@ -156,8 +158,13 @@ _Cache subdirectory_ - name of the sub-directory (withing `$HOME/.arquillian/dro
 
 |Cache subdirectory
 |internetExplorer
+
+|Architecture
+|ieDriverArch +
+Supported values: "Win32" and "x64"
 |===
 
+The architecture of the binary can be explicitly specified because the 64 bit version of the IE driver is having issues with `sendKeys` method at some specific conditions.
 
 ===== PhantomJS
 |===

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/SeleniumServerBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/SeleniumServerBinaryHandler.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.logging.Logger;
 
+import static org.jboss.arquillian.drone.webdriver.utils.Validate.empty;
+
 /**
  * A class for handling selenium server binaries. It also runs the selenium server with properties that are
  * appropriately configured
@@ -73,7 +75,7 @@ public class SeleniumServerBinaryHandler extends AbstractBinaryHandler {
 
         @Override
         protected String getExpectedKeyRegex(String requiredVersion, String directory) {
-            if (version == null) {
+            if (empty(version)) {
                 return directory + "/" + getFileNameRegexToDownload(directory + ".*");
             } else {
                 return getDirectoryFromFullVersion(version) + "/" + getFileNameRegexToDownload(version);

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/GoogleSeleniumStorageProvider.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/GoogleSeleniumStorageProvider.java
@@ -9,7 +9,7 @@ import org.jboss.arquillian.drone.webdriver.utils.HttpClient;
 public class GoogleSeleniumStorageProvider {
 
     public static ExternalBinarySource getIeStorageSource(String version, HttpClient httpClient) {
-        return new InternetExplorerBinaryHandler.IeStorageSource(version, httpClient);
+        return new InternetExplorerBinaryHandler.IeStorageSource(version, null, httpClient);
     }
 
     public static ExternalBinarySource getSeleniumServerStorageSource(String version, HttpClient httpClient) {


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Adds the support for specifying the architecture for IE driver binary.
Includes some fixes as well - please see bellow.

#### Changes proposed in this pull request:
- Basically adds `ieDriverArch` property. If it's not specified then it just falls back to the original behavior - downloads the binary based on the OS architecture.
- Adds proper emptiness check for `ieDriverVersion` and `seleniumServerVersion`. Before, when those properties were specified but empty, it caused `StringIndexOutOfBoundsException`.


**Fixes**: #
`StringIndexOutOfBoundsException`