### PR TITLE
fix(chromeOptions): When experimental option json is parsed then it checks what is the type of the value

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
@@ -105,9 +105,14 @@ public class CapabilitiesOptionsMapper {
 
         for (Map.Entry<String, JsonElement> entry : entries) {
             String key = entry.getKey();
-            Map<String, String> values = GSON.fromJson(entry.getValue(), type);
+            Object value = null;
+            if (entry.getValue().isJsonObject()) {
+                value = GSON.fromJson(entry.getValue(), type);
 
-            method.invoke(object, key, values);
+            } else if (entry.getValue().isJsonPrimitive()) {
+                value = entry.getValue().getAsString();
+            }
+            method.invoke(object, key, value);
         }
     }
 

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesChromeOptionsMapperTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesChromeOptionsMapperTest.java
@@ -93,4 +93,23 @@ public class CapabilitiesChromeOptionsMapperTest {
 
         Assertions.assertThat(expectedChromeOptions).isEqualToComparingFieldByFieldRecursively(chromeOptions);
     }
+
+    // reproducer for https://github.com/arquillian/arquillian-extension-drone/issues/114
+    @Test
+    public void testParseChromeOptionsWithSimpleJsonAsExperimentalOption() throws IOException {
+        // given
+        ChromeOptions chromeOptions = new ChromeOptions();
+        DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
+
+        String experimentalOptionJson = "{\"useAutomationExtension\": \"false\"}";
+        desiredCapabilities.setCapability("chromeExperimentalOption", experimentalOptionJson);
+
+        // when
+        CapabilitiesOptionsMapper.mapCapabilities(chromeOptions, desiredCapabilities, "chrome");
+
+        //then
+        ChromeOptions expectedChromeOptions = new ChromeOptions();
+        expectedChromeOptions.setExperimentalOption("useAutomationExtension", "false");
+        Assertions.assertThat(chromeOptions).isEqualToComparingFieldByFieldRecursively(expectedChromeOptions);
+    }
 }


### PR DESCRIPTION
the option mapper checks if the value is a json or primitive type to support also:  
```xml
  <extension qualifier="webdriver">
    <property name="chromeExperimentalOption">
    {
      "useAutomationExtension": "false"
    }
    </property>
  </extension>
```
**Fixes**: #114 
