### PR TITLE
Allow typed primitive option values other than strings

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
@@ -110,10 +111,21 @@ public class CapabilitiesOptionsMapper {
                 value = GSON.fromJson(entry.getValue(), type);
 
             } else if (entry.getValue().isJsonPrimitive()) {
-                value = entry.getValue().getAsString();
+                value = convertJsonPrimitive2Java((JsonPrimitive) entry.getValue());
             }
             method.invoke(object, key, value);
         }
+    }
+
+    private static Object convertJsonPrimitive2Java(JsonPrimitive primitive) {
+        if (primitive.isBoolean()) {
+            return primitive.getAsBoolean();
+        } else if (primitive.isNumber()) {
+            return primitive.getAsNumber();
+        } else if (primitive.isString()) {
+            return primitive.getAsString();
+        }
+        throw new RuntimeException("Unhandled json primitive " + primitive);
     }
 
     private static boolean shouldContainDictionaries(Method method) {

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesChromeOptionsMapperTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesChromeOptionsMapperTest.java
@@ -101,7 +101,10 @@ public class CapabilitiesChromeOptionsMapperTest {
         ChromeOptions chromeOptions = new ChromeOptions();
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
 
-        String experimentalOptionJson = "{\"useAutomationExtension\": \"false\"}";
+        String experimentalOptionJson = "{" +
+            "\"booleanOption\": false," +
+            "\"stringOption\": \"hello\"" +
+            "}";
         desiredCapabilities.setCapability("chromeExperimentalOption", experimentalOptionJson);
 
         // when
@@ -109,7 +112,8 @@ public class CapabilitiesChromeOptionsMapperTest {
 
         //then
         ChromeOptions expectedChromeOptions = new ChromeOptions();
-        expectedChromeOptions.setExperimentalOption("useAutomationExtension", "false");
+        expectedChromeOptions.setExperimentalOption("booleanOption", false);
+        expectedChromeOptions.setExperimentalOption("stringOption", "hello");
         Assertions.assertThat(chromeOptions).isEqualToComparingFieldByFieldRecursively(expectedChromeOptions);
     }
 }


### PR DESCRIPTION
Unfortunately, the fix for https://github.com/arquillian/arquillian-extension-drone/issues/114 does not work with selenium. I should have specified the json primitive false instead of the string "false". 

This pull requst allows one to specify a boolean: 
```

<property name="chromeExperimentalOption">
    {
      "useAutomationExtension": false
    }
    </property>
```