### PR TITLE
fix(ARQ-2154): refactored usage of files to nio Path & changed relative paths to absolute

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/BinaryFilesUtils.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/BinaryFilesUtils.java
@@ -41,7 +41,7 @@ public class BinaryFilesUtils {
         if (dir == null) {
             dir = UUID.randomUUID().toString();
         }
-        File targetDir = new File(DRONE_TARGET_DIRECTORY + File.separator + dir);
+        File targetDir = DRONE_TARGET_DIRECTORY.resolve(dir).toFile();
 
         synchronized (log) {
             if (!targetDir.exists() || targetDir.listFiles().length == 0) {
@@ -61,7 +61,7 @@ public class BinaryFilesUtils {
                         "The file " + toExtract + " is not compressed by a format that is supported by Drone. "
                             + "Drone supported formats are .zip, .tar.gz, .tar.bz2. The file will be only copied");
                     targetDir.mkdirs();
-                    Files.copy(toExtract.toPath(), new File(targetDir + File.separator + toExtract.getName()).toPath(),
+                    Files.copy(toExtract.toPath(), targetDir.toPath().resolve(toExtract.getName()),
                         StandardCopyOption.REPLACE_EXISTING);
                 }
             }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/Downloader.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/Downloader.java
@@ -2,6 +2,7 @@ package org.jboss.arquillian.drone.webdriver.binary.downloading;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.logging.Logger;
 import org.arquillian.spacelift.Spacelift;
 import org.arquillian.spacelift.execution.Execution;
@@ -15,8 +16,7 @@ import static org.jboss.arquillian.drone.webdriver.utils.Constants.DRONE_TARGET_
  */
 public class Downloader {
 
-    public static final String DRONE_TARGET_DOWNLOADED_DIRECTORY =
-        DRONE_TARGET_DIRECTORY + "downloaded" + File.separator;
+    public static final Path DRONE_TARGET_DOWNLOADED_DIRECTORY = DRONE_TARGET_DIRECTORY.resolve("downloaded");
     private static final Logger log = Logger.getLogger(Downloader.class.toString());
 
     /**
@@ -32,7 +32,7 @@ public class Downloader {
      */
     public static File download(File targetDir, URL from) {
         if (targetDir == null) {
-            targetDir = new File(DRONE_TARGET_DOWNLOADED_DIRECTORY);
+            targetDir = DRONE_TARGET_DOWNLOADED_DIRECTORY.toFile();
         }
         String fromUrl = from.toString();
         String fileName = fromUrl.substring(fromUrl.lastIndexOf("/") + 1);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/AbstractBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/AbstractBinaryHandler.java
@@ -1,5 +1,6 @@
 package org.jboss.arquillian.drone.webdriver.binary.handler;
 
+import java.nio.file.Path;
 import org.jboss.arquillian.drone.webdriver.binary.BinaryFilesUtils;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.Downloader;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
@@ -267,10 +268,9 @@ public abstract class AbstractBinaryHandler implements BinaryHandler {
     }
 
     protected File createAndGetCacheDirectory(String subdirectory) {
-        String dirPath = Constants.ARQUILLIAN_DRONE_CACHE_DIRECTORY
-            + getArquillianCacheSubdirectory()
-            + (subdirectory == null ? "" : File.separator + subdirectory);
-        File dir = new File(dirPath);
+        Path dirPath = Constants.ARQUILLIAN_DRONE_CACHE_DIRECTORY.resolve(getArquillianCacheSubdirectory())
+            .resolve(subdirectory == null ? "" : subdirectory);
+        File dir = dirPath.toFile();
         dir.mkdirs();
         return dir;
     }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Constants.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/Constants.java
@@ -16,7 +16,8 @@
  */
 package org.jboss.arquillian.drone.webdriver.utils;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  *
@@ -39,12 +40,10 @@ public class Constants {
     public static final String SAFARI_DRIVER = "org.openqa.selenium.safari.SafariDriver";
     public static final String PHANTOMJS_DRIVER = "org.openqa.selenium.phantomjs.PhantomJSDriver";
 
-    public static final String ARQUILLIAN_DRONE_CACHE_DIRECTORY =
-        System.getProperty("user.home") + File.separator
-            + ".arquillian" + File.separator
-            + "drone" + File.separator;
+    public static final Path ARQUILLIAN_DRONE_CACHE_DIRECTORY =
+        Paths.get(System.getProperty("user.home"), ".arquillian", "drone");
 
-    public static final String DRONE_TARGET_DIRECTORY =
-        "target" + File.separator + "drone" + File.separator;
+    public static final Path DRONE_TARGET_DIRECTORY =
+        Paths.get(System.getProperty("user.dir"), "target" , "drone");
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:

I changed most of the `File` usages to `Path`. It will be easier to keep the whole path by using the fluent API instead of joining strings and `File.separator`
In addition, I changed the relative paths to absolute ones as it was causing an issue in non-forked tests.

