### PR TITLE
fix(#126): removes arquillian-drone-selenium-server from BOM

### DIFF
--- a/drone-bom/pom.xml
+++ b/drone-bom/pom.xml
@@ -73,11 +73,6 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-selenium-server</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-drone-webdriver</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes: #126 