### PR TITLE
fix(download): case insensitive headers in HttpClient.Response

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java
@@ -141,8 +141,11 @@ public abstract class GitHubSource implements ExternalBinarySource {
 
     protected ZonedDateTime extractModificationDate(HttpClient.Response response) {
         final String modificationDate = response.getHeader(LAST_MODIFIED);
-        final DateTimeFormatter dateTimeFormatter = Rfc2126DateTimeFormatter.INSTANCE;
-        return ZonedDateTime.parse(modificationDate, dateTimeFormatter);
+        if (modificationDate != null) {
+            final DateTimeFormatter dateTimeFormatter = Rfc2126DateTimeFormatter.INSTANCE;
+            return ZonedDateTime.parse(modificationDate, dateTimeFormatter);
+        }
+        return ZonedDateTime.now();
     }
 
     @Override

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/HttpClient.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/utils/HttpClient.java
@@ -66,7 +66,8 @@ public class HttpClient {
             }
             final Map<String, String> headers = new HashMap<>();
             for (Header header : response.getAllHeaders()) {
-                headers.put(header.getName(), header.getValue());
+                // Names should be case-insensitive
+                headers.put(header.getName().toLowerCase(), header.getValue());
             }
             return new Response(payload, headers);
         }
@@ -80,7 +81,7 @@ public class HttpClient {
         }
 
         public String getHeader(String header) {
-            return headers.get(header);
+            return headers.get(header.toLowerCase());
         }
     }
 }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/utils/HttpClientResponseTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/utils/HttpClientResponseTest.java
@@ -1,0 +1,38 @@
+package org.jboss.arquillian.drone.webdriver.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import org.apache.http.Header;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+
+public class HttpClientResponseTest {
+
+    @Test
+    public void testHeaders() throws IOException {
+        String now = ZonedDateTime.now().toString();
+        Header[] headers = new Header[] { new BasicHeader("last-modified", now), new BasicHeader("Foo-Modified", now) };
+        HttpClient.Response response = HttpClient.Response
+                .from(new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "")) {
+                    @Override
+                    public Header[] getAllHeaders() {
+                        return headers;
+                    }
+                });
+
+        String header = response.getHeader(org.apache.http.HttpHeaders.LAST_MODIFIED);
+        assertNotNull(header);
+        assertEquals(now, header);
+        header = response.getHeader("foo-modified");
+        assertNotNull(header);
+        assertEquals(now, header);
+    }
+
+}


### PR DESCRIPTION
- header names should be case-insensitive
- also fallback to "now" when the Last-Modified header is absent

#### Short description of what this resolves:

We're observing problems with downloading the latest Firefox driver due to the fact that a response from the GitHub API contains a header with name `last-modified` but drone expects `Last-Modified`. As a result a `NullPointerException` is thrown from a [ZonedDateTime.parse()](https://github.com/arquillian/arquillian-extension-drone/blob/master/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/downloading/source/GitHubSource.java#L145) invocation.
