### PR TITLE
fix(ci): switches to openjdk8 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Oldest oraclejdk seems to be JDK9 on Travis right now, switching to OpenJDK instead.
