### PR TITLE
fix: fails when previously downloaded file doesn't exist

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/AbstractBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/AbstractBinaryHandler.java
@@ -235,6 +235,9 @@ public abstract class AbstractBinaryHandler implements BinaryHandler {
      * @throws Exception If anything bad happens
      */
     protected File prepare(File downloaded) throws Exception {
+        if (!downloaded.exists()) {
+            throw new IllegalStateException("Downloaded file '" + downloaded.getPath() + "' doesn't exist, the download probably failed");
+        }
         File extraction = BinaryFilesUtils.extract(downloaded);
         File[] files = extraction.listFiles(file -> file.isFile());
         if (files == null || files.length == 0) {


### PR DESCRIPTION
Throw `IllegalStateException` in case the downloaded file passed to `AbstractBinaryHandler.prepare` doesn't exist in order to avoid less intuitive error message during extraction.

#### Short description of what this resolves:
Non-intuitive error message in case a downloaded binary vanishes after download

#### Changes proposed in this pull request:

- Throw IllegalStateException if downloaded file vanished
