### PR TITLE
feat(chrome): downloads driver version for Apple Silicon

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
@@ -135,6 +135,10 @@ public class ChromeDriverBinaryHandler extends AbstractBinaryHandler {
 
             fileName.append(architecture.getValue());
 
+            if (PlatformUtils.isMacAppleSilicon()) {
+                fileName.append("_m1");
+            }
+
             return fileName.append(".zip").toString();
         }
     }


### PR DESCRIPTION
Use the M1 build of the Goggle Chrome WebDriver on Apple Silicon


There is an extra build of Google Chrome WebDriver for Apple Silicon. The name of the binary has an additional _m1 at the end. The x64 driver essentially works but starts Chrome in Rosetta. The M1 binary speeds the tests quit significantly.