### PR TITLE
fix(chromedriver): ensures to extract binary

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
@@ -78,7 +78,7 @@ public class ChromeDriverBinaryHandler extends AbstractBinaryHandler {
 
         if (files == null || files.length != 1) {
             throw new IllegalStateException(
-                "Missing ChromeDriver executable (" + CHROME_DRIVER_BINARY_NAME + " in the directory " + extraction);
+                "Missing ChromeDriver executable (" + CHROME_DRIVER_BINARY_NAME + ") in the directory " + extraction);
         }
 
         return markAsExecutable(files[0]);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
@@ -1,9 +1,11 @@
 package org.jboss.arquillian.drone.webdriver.binary.handler;
 
+import java.io.File;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jboss.arquillian.drone.webdriver.binary.BinaryFilesUtils;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.ExternalBinary;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.source.ExternalBinarySource;
 import org.jboss.arquillian.drone.webdriver.binary.downloading.source.MissingBinaryException;
@@ -25,6 +27,8 @@ public class ChromeDriverBinaryHandler extends AbstractBinaryHandler {
     public static final String CHROME_DRIVER_BINARY_PROPERTY = "chromeDriverBinary";
     private static final String CHROME_DRIVER_VERSION_PROPERTY = "chromeDriverVersion";
     private static final String CHROME_DRIVER_URL_PROPERTY = "chromeDriverUrl";
+
+    public static final String CHROME_DRIVER_BINARY_NAME = "chromedriver" + (PlatformUtils.isWindows() ? ".exe" : "");
 
     private final DesiredCapabilities capabilities;
 
@@ -65,6 +69,19 @@ public class ChromeDriverBinaryHandler extends AbstractBinaryHandler {
     @Override
     public String getSystemBinaryProperty() {
         return CHROME_SYSTEM_DRIVER_BINARY_PROPERTY;
+    }
+
+    @Override
+    protected File prepare(File downloaded) throws Exception {
+        File extraction = BinaryFilesUtils.extract(downloaded);
+        File[] files = extraction.listFiles(file -> file.isFile() && file.getName().equals(CHROME_DRIVER_BINARY_NAME));
+
+        if (files == null || files.length != 1) {
+            throw new IllegalStateException(
+                "Missing ChromeDriver executable (" + CHROME_DRIVER_BINARY_NAME + " in the directory " + extraction);
+        }
+
+        return markAsExecutable(files[0]);
     }
 
     public static class ChromeStorageSources extends UrlStorageSource {


### PR DESCRIPTION
#### Short description of what this resolves:

ChromeDriver 109.0.5414.25 changed the contents of the driver archive to include a license file (`LICENSE.chromedriver`). When `ChromeDriverBinaryHandler` prepares the driver it attempts to make this license file executable which causes an exception to be raised:

```text
INFO: Extracting zip file: /home/jenkins/.arquillian/drone/chrome/109.0.5414.74/chromedriver_linux64.zip to /home/jenkins/workspace/example/target/drone/245747a6d5f2b7da02c465941f43e0e8
Jan 11, 2023 11:39:47 AM org.jboss.arquillian.drone.webdriver.binary.handler.AbstractBinaryHandler markAsExecutable
INFO: marking binary file: /home/jenkins/workspace/example/target/drone/245747a6d5f2b7da02c465941f43e0e8/LICENSE.chromedriver as executable
/home/jenkins/workspace/example/target/drone/245747a6d5f2b7da02c465941f43e0e8/LICENSE.chromedriver: line 1: //: Is a directory
/home/jenkins/workspace/example/target/drone/245747a6d5f2b7da02c465941f43e0e8/LICENSE.chromedriver: line 2: //: Is a directory
/home/jenkins/workspace/example/target/drone/245747a6d5f2b7da02c465941f43e0e8/LICENSE.chromedriver: line 3: //: Is a directory
...
```

The current behaviour grabs the first file in the extracted archive - on our CI system this happens to be the license file and not the driver.

#### Changes proposed in this pull request:

This PR changes the logic to find the ChromeDriver binary by filename instead of grabbing the first file.
