### PR TITLE
fix: Use ARM version of ChromeDriver on Apple Silicon

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeDriverBinaryHandler.java
@@ -127,6 +127,9 @@ public class ChromeDriverBinaryHandler extends AbstractBinaryHandler {
             fileName.append("chromedriver_");
             if (PlatformUtils.isMac()) {
                 fileName.append("mac");
+                if (PlatformUtils.isMacAppleSilicon()) {
+                    fileName.append("_arm");
+                }
             } else if (PlatformUtils.isWindows()) {
                 fileName.append("win");
             } else if (PlatformUtils.isUnix()) {

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeStorageSourcesTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeStorageSourcesTest.java
@@ -1,0 +1,122 @@
+package org.jboss.arquillian.drone.webdriver.binary.handler;
+
+import org.jboss.arquillian.drone.webdriver.binary.downloading.source.MissingBinaryException;
+import org.jboss.arquillian.drone.webdriver.utils.Architecture;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.jboss.arquillian.drone.webdriver.binary.handler.ChromeDriverBinaryHandler.ChromeStorageSources;
+
+public class ChromeStorageSourcesTest {
+    private final ChromeStorageSources sources = new ChromeStorageSources("https:/chrome.example.com/");
+
+    private static final String REAL_OS = System.getProperty("os.name");
+    private static final String REAL_ARCH = System.getProperty("os.arch");
+
+    private static final String CHROME_VERSION = "111.0.5563.19";
+
+    @After
+    public void resetOsProperties() {
+        overrideSystemProperties(REAL_OS, REAL_ARCH);
+    }
+
+    @Test
+    public void testWindowsDownload() {
+        overrideSystemProperties("win", "x86");
+
+        String filename = sources.getFileNameRegexToDownload(CHROME_VERSION, Architecture.BIT32);
+        Assert.assertEquals("111.0.5563.19/chromedriver_win32.zip", filename);
+    }
+
+    @Test
+    public void testLinux64Download() {
+        overrideSystemProperties("linux", "x86_64");
+
+        String filename = sources.getFileNameRegexToDownload(CHROME_VERSION, Architecture.BIT64);
+        Assert.assertEquals("111.0.5563.19/chromedriver_linux64.zip", filename);
+    }
+
+    @Test
+    public void testLinux32Download() {
+        overrideSystemProperties("linux", "x86");
+
+        String filename = sources.getFileNameRegexToDownload("2.3", Architecture.BIT32);
+        Assert.assertEquals("2.3/chromedriver_linux32.zip", filename);
+    }
+
+    @Test
+    public void testLinux32DownloadInvalidVersion() {
+        overrideSystemProperties("linux", "x86");
+
+        MissingBinaryException exception = Assert.assertThrows(MissingBinaryException.class, () ->
+            sources.getFileNameRegexToDownload(CHROME_VERSION, Architecture.BIT32));
+
+        Assert.assertTrue("Error message", exception.getMessage().startsWith("32bit Linux is not supported after"));
+    }
+
+    @Test
+    public void testMacIntel64Download() {
+        overrideSystemProperties("Mac OS X", "x86_64");
+
+        String filename = sources.getFileNameRegexToDownload(CHROME_VERSION, Architecture.BIT64);
+        Assert.assertEquals("111.0.5563.19/chromedriver_mac64.zip", filename);
+    }
+
+    @Test
+    public void testMacIntel64DownloadInvalidVersion() {
+        overrideSystemProperties("Mac OS X", "x86_64");
+
+        MissingBinaryException exception = Assert.assertThrows(MissingBinaryException.class, () ->
+            sources.getFileNameRegexToDownload("2.22", Architecture.BIT64));
+
+        Assert.assertTrue("Error message", exception.getMessage().startsWith("64bit macOS is not supported before"));
+    }
+
+    @Test
+    public void testMacIntel32Download() {
+        overrideSystemProperties("Mac OS X", "x86");
+
+        String filename = sources.getFileNameRegexToDownload("2.17", Architecture.BIT32);
+        Assert.assertEquals("2.17/chromedriver_mac32.zip", filename);
+    }
+
+    @Test
+    public void testMacIntel32DownloadInvalidVersion() {
+        overrideSystemProperties("Mac OS X", "x86");
+
+        MissingBinaryException exception = Assert.assertThrows(MissingBinaryException.class, () ->
+            sources.getFileNameRegexToDownload(CHROME_VERSION, Architecture.BIT32));
+
+        Assert.assertTrue("Error message", exception.getMessage().startsWith("32bit macOS is not supported after"));
+    }
+
+    @Test
+    public void testMacAppleSiliconDownload() {
+        overrideSystemProperties("Mac OS X", "aarch64");
+
+        String filename = sources.getFileNameRegexToDownload(CHROME_VERSION, Architecture.BIT64);
+        Assert.assertEquals("111.0.5563.19/chromedriver_mac_arm64.zip", filename);
+    }
+
+    @Test
+    public void testMacAppleSiliconM1VersionDownload() {
+        overrideSystemProperties("Mac OS X", "aarch64");
+
+        String filename = sources.getFileNameRegexToDownload("106.0.5249.0", Architecture.BIT64);
+        Assert.assertEquals("106.0.5249.0/chromedriver_mac64_m1.zip", filename);
+    }
+
+    @Test
+    public void testMacAppleSiliconIntelFallbackDownload() {
+        overrideSystemProperties("Mac OS X", "aarch64");
+
+        String filename = sources.getFileNameRegexToDownload("87.0.4280.20", Architecture.BIT64);
+        Assert.assertEquals("87.0.4280.20/chromedriver_mac64.zip", filename);
+    }
+
+    private void overrideSystemProperties(String os, String arch) {
+        System.setProperty("os.name", os);
+        System.setProperty("os.arch", arch);
+    }
+}

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeVersionTest.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/handler/ChromeVersionTest.java
@@ -1,0 +1,136 @@
+package org.jboss.arquillian.drone.webdriver.binary.handler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.jboss.arquillian.drone.webdriver.binary.handler.ChromeDriverBinaryHandler.ChromeVersion;
+
+public class ChromeVersionTest {
+    private static final ChromeVersion TEST_VERSION = new ChromeVersion(10, 20, 30, 40);
+
+    @Test
+    public void testParseVersion() {
+        ChromeVersion parsed = new ChromeVersion("111.0.5563.19");
+
+        Assert.assertEquals("Parsed major", 111, parsed.major);
+        Assert.assertEquals("Parsed minor", 0, parsed.minor);
+        Assert.assertEquals("Parsed patch", 5563, parsed.patch);
+        Assert.assertEquals("Parsed build", 19, parsed.build);
+    }
+
+    @Test
+    public void testParseLegacyVersion() {
+        ChromeVersion parsed = new ChromeVersion("2.22");
+
+        Assert.assertEquals("Parsed major", 2, parsed.major);
+        Assert.assertEquals("Parsed minor", 22, parsed.minor);
+        Assert.assertEquals("Parsed patch", 0, parsed.patch);
+        Assert.assertEquals("Parsed build", 0, parsed.build);
+    }
+
+    @Test
+    public void testIsAfterSameVersion() {
+        Assert.assertFalse("isAfter same version", TEST_VERSION.isAfter(TEST_VERSION));
+    }
+
+    @Test
+    public void testIsAfterNewerMajor() {
+        ChromeVersion version = new ChromeVersion(11, 20, 30, 40);
+        Assert.assertFalse(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterOlderMajor() {
+        ChromeVersion version = new ChromeVersion(9, 20, 30, 40);
+        Assert.assertTrue(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterNewerMinor() {
+        ChromeVersion version = new ChromeVersion(10, 21, 30, 40);
+        Assert.assertFalse(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterOlderMinor() {
+        ChromeVersion version = new ChromeVersion(10, 19, 30, 40);
+        Assert.assertTrue(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterNewerPatch() {
+        ChromeVersion version = new ChromeVersion(10, 20, 31, 40);
+        Assert.assertFalse(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterOlderPatch() {
+        ChromeVersion version = new ChromeVersion(10, 20, 29, 40);
+        Assert.assertTrue(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterNewerBuild() {
+        ChromeVersion version = new ChromeVersion(10, 20, 30, 41);
+        Assert.assertFalse(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsAfterOlderBuild() {
+        ChromeVersion version = new ChromeVersion(10, 20, 30, 39);
+        Assert.assertTrue(TEST_VERSION.isAfter(version));
+    }
+
+    @Test
+    public void testIsBeforeSameVersion() {
+        Assert.assertFalse("isBefore same version", TEST_VERSION.isBefore(TEST_VERSION));
+    }
+
+    @Test
+    public void testIsBeforeNewerMajor() {
+        ChromeVersion version = new ChromeVersion(11, 20, 30, 40);
+        Assert.assertTrue(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeOlderMajor() {
+        ChromeVersion version = new ChromeVersion(9, 20, 30, 40);
+        Assert.assertFalse(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeNewerMinor() {
+        ChromeVersion version = new ChromeVersion(10, 21, 30, 40);
+        Assert.assertTrue(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeOlderMinor() {
+        ChromeVersion version = new ChromeVersion(10, 19, 30, 40);
+        Assert.assertFalse(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeNewerPatch() {
+        ChromeVersion version = new ChromeVersion(10, 20, 31, 40);
+        Assert.assertTrue(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeOlderPatch() {
+        ChromeVersion version = new ChromeVersion(10, 20, 29, 40);
+        Assert.assertFalse(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeNewerBuild() {
+        ChromeVersion version = new ChromeVersion(10, 20, 30, 41);
+        Assert.assertTrue(TEST_VERSION.isBefore(version));
+    }
+
+    @Test
+    public void testIsBeforeOlderBuild() {
+        ChromeVersion version = new ChromeVersion(10, 20, 30, 39);
+        Assert.assertFalse(TEST_VERSION.isBefore(version));
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

On Apple Silicon Macs the Intel version of ChromeDriver (`chromedriver_mac64.zip`) is used instead of the ARM version (`chromedriver_mac_arm64.zip`).


#### Changes proposed in this pull request:

This PR adds a check for `isMacAppleSilicon` and inserts `_arm` into the filename if matched.
