### PR TITLE
fix: runs browser-tools scripts in /tmp folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         type: string
       browser:
         type: string
-    working_directory: $HOME/circleci-arquillian
+    working_directory: /home/circleci/circleci-arquillian
     docker:
       - image: cimg/openjdk:<< parameters.jdk-version >>-browsers
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.3.0
+  browser-tools: circleci/browser-tools@1.4.1
 jobs:
   build:
     parameters:
@@ -13,6 +13,7 @@ jobs:
       - image: cimg/openjdk:<< parameters.jdk-version >>-browsers
     resource_class: large
     steps:
+      - run: cd /tmp
       - browser-tools/install-browser-tools
       - run:
           name: "Install Microsoft Edge for Linux"
@@ -25,6 +26,7 @@ jobs:
             ## Install
             sudo apt update
             sudo apt install microsoft-edge-beta -y
+      - run: cd -
       - checkout
       - restore_cache:
           key: circleci-arquillian-extension-drone-{{ checksum "pom.xml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             ## Install
             sudo apt update
             sudo apt install microsoft-edge-beta -y
-      - run: cd -
+      - run: cd "${CIRCLE_WORKING_DIRECTORY}"
       - checkout
       - restore_cache:
           key: circleci-arquillian-extension-drone-{{ checksum "pom.xml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         type: string
       browser:
         type: string
-    working_directory: ~/circleci-arquillian
+    working_directory: $HOME/circleci-arquillian
     docker:
       - image: cimg/openjdk:<< parameters.jdk-version >>-browsers
     resource_class: large


### PR DESCRIPTION
This way we avoid leaving any left-overs such as `LICENSE.chromedriver` in the working directory leading to failure on git clone, as the directory is not empty.

