### PR TITLE
fix(ci): backports CI changes to 2.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ jobs:
     resource_class: large
     steps:
       - run: cd /tmp
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          replace-existing-chrome: true
       - run:
           name: "Install Microsoft Edge for Linux"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.4.1
 jobs:
   build:
     parameters:
@@ -8,10 +8,12 @@ jobs:
         type: string
       browser:
         type: string
-    working_directory: ~/circleci-arquillian
+    working_directory: /home/circleci/circleci-arquillian
     docker:
       - image: cimg/openjdk:<< parameters.jdk-version >>-browsers
+    resource_class: large
     steps:
+      - run: cd /tmp
       - browser-tools/install-browser-tools
       - run:
           name: "Install Microsoft Edge for Linux"
@@ -24,6 +26,7 @@ jobs:
             ## Install
             sudo apt update
             sudo apt install microsoft-edge-beta -y
+      - run: cd "${CIRCLE_WORKING_DIRECTORY}"
       - checkout
       - restore_cache:
           key: circleci-arquillian-extension-drone-{{ checksum "pom.xml" }}


### PR DESCRIPTION
#### Short description of what this resolves:
CI builds on the `v2-support` branch are failing due to git clone errors caused by browser-tools leaving files in the working directory. This has been solved in the `master` branch.

#### Changes proposed in this pull request:
Applies the CI changes made in ea4b04d and #376.