### PR TITLE
fix: unblocks phantomjs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,11 @@ jobs:
       - restore_cache:
           key: circleci-arquillian-extension-drone-{{ checksum "pom.xml" }}
       - run: ./mvnw verify -q -U -DskipTests
-      - run: ./mvnw verify -Dbrowser=<< parameters.browser >>
+      - run: 
+          name: "Run tests"
+          command: ./mvnw verify -Dbrowser=<< parameters.browser >>
+          environment:
+            OPENSSL_CONF: /dev/null
       - store_test_results:
           path: target/surefire-reports
       - save_cache:


### PR DESCRIPTION
Sets env variable of `OPENSSL` for nodejs to unblock the tests. 

See https://github.com/nodejs/node/issues/43132\#issuecomment-1130503287
