### PR TITLE
v2: JDK 21 runtime compatibility 

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/SerializationWhitelist.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/remote/reusable/SerializationWhitelist.java
@@ -43,7 +43,6 @@ public class SerializationWhitelist {
         whitelist.add(Character.UnicodeBlock.class.getName());
         whitelist.add(Class.class.getName());
         whitelist.add(ClassLoader.class.getName());
-        whitelist.add(Compiler.class.getName());
         whitelist.add(Double.class.getName());
         whitelist.add(Enum.class.getName());
         whitelist.add(Float.class.getName());


### PR DESCRIPTION
removed Compiler.class from serialization whitelist due to incompatibility with JDK 21

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
JDK 21 runtime compatibility
