### PR TITLE
enh: add functionality to enable BIDI via configuration

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/configuration/WebDriverConfiguration.java
@@ -66,6 +66,8 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
 
     private String dimensions;
 
+    private boolean enableBidi;
+
     private Map<String, Object> capabilityMap;
 
     // internal variables
@@ -194,5 +196,13 @@ public class WebDriverConfiguration implements DroneConfiguration<WebDriverConfi
 
     public void setReuseCookies(boolean reuseCookies) {
         this.reuseCookies = reuseCookies;
+    }
+
+    public boolean isEnableBidi() {
+        return enableBidi;
+    }
+
+    public void setEnableBidi(boolean enableBidi) {
+        this.enableBidi = enableBidi;
     }
 }

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/CapabilitiesOptionsMapper.java
@@ -144,7 +144,7 @@ public class CapabilitiesOptionsMapper {
                     || method.getParameterTypes()[1].isAssignableFrom(Map.class));
     }
 
-    private static Object convert(Method method, String capability) {
+    private static <T extends Enum<T>> Object convert(Method method, String capability) {
         Class<?> parameterType = method.getParameterTypes()[0];
         Object converted;
 
@@ -154,6 +154,10 @@ public class CapabilitiesOptionsMapper {
             return handleArray(parameterType.getComponentType(), capability);
         } else if (parameterType.isAssignableFrom(List.class)) {
             return handleList(method, capability);
+        } else if (parameterType.isEnum()) {
+            @SuppressWarnings("unchecked")
+            Class<T> enumType = (Class<T>) parameterType;
+            return Enum.valueOf(enumType, capability.toUpperCase());
         }
 
         return null;

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/ChromeDriverFactory.java
@@ -102,6 +102,10 @@ public class ChromeDriverFactory extends AbstractWebDriverFactory<ChromeDriver> 
      */
     public ChromeOptions getChromeOptions(WebDriverConfiguration configuration, boolean performValidations) {
         ChromeOptions chromeOptions = new ChromeOptions();
+        if (configuration.isEnableBidi()) {
+            chromeOptions.enableBiDi();
+        }
+
         Capabilities capabilities = configuration.getCapabilities();
         final String binary = (String) capabilities.getCapability("chrome.binary");
         final String version = ChromeUtils.getChromeVersion(capabilities);

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/EdgeDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/EdgeDriverFactory.java
@@ -64,6 +64,9 @@ public class EdgeDriverFactory extends AbstractWebDriverFactory<EdgeDriver> impl
     public EdgeOptions getEdgeOptions(WebDriverConfiguration configuration) {
         Capabilities capabilities = configuration.getCapabilities();
         EdgeOptions edgeOptions = new EdgeOptions();
+        if (configuration.isEnableBidi()) {
+            edgeOptions.enableBiDi();
+        }
         CapabilitiesOptionsMapper.mapCapabilities(edgeOptions, capabilities, BROWSER_CAPABILITIES);
 
         return edgeOptions;

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/FirefoxDriverFactory.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/factory/FirefoxDriverFactory.java
@@ -108,6 +108,10 @@ public class FirefoxDriverFactory extends AbstractWebDriverFactory<FirefoxDriver
 
         // using FirefoxOptions which is now the preferred way for configuring GeckoDriver
         FirefoxOptions firefoxOptions = new FirefoxOptions();
+        if (configuration.isEnableBidi()) {
+            firefoxOptions.enableBiDi();
+        }
+
         CapabilitiesOptionsMapper.mapCapabilities(firefoxOptions, capabilities, BROWSER_CAPABILITIES);
 
         FirefoxProfile firefoxProfile = getFirefoxProfile(capabilities, performValidations);


### PR DESCRIPTION
#### Short description of what this resolves:
Selenium BiDi (bidirectional browser comm via WebSocket) has been implemented
This PR adds ability to turn BiDi on via configuration:
`<property name="enableBidi">true</property>`
May also require
`<property name="unhandledPromptBehaviour">ignore</property>` to prevent bidi from auto-dismissing dialogs

fixes #545
