### PR TITLE
Remove workarounds

### DIFF
--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/augmentation/AugmentingEnhancer.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/augmentation/AugmentingEnhancer.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.drone.webdriver.factory.remote.reusable.ReusableRemo
 import org.jboss.arquillian.drone.webdriver.spi.DroneAugmented;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.devtools.CdpEndpointFinder;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -81,10 +80,7 @@ public class AugmentingEnhancer implements DroneInstanceEnhancer<RemoteWebDriver
      */
     @Override
     public RemoteWebDriver enhance(RemoteWebDriver instance, Class<? extends Annotation> qualifier) {
-        if (CdpEndpointFinder.getReportedUri(instance.getCapabilities()).isPresent()) {
-            return (RemoteWebDriver) augmenter.augment(instance);
-        }
-        return instance;
+        return (RemoteWebDriver) augmenter.augment(instance);
     }
 
     /**

--- a/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/augmentation/AugmentingEnhancer.java
+++ b/drone-webdriver/src/main/java/org/jboss/arquillian/drone/webdriver/augmentation/AugmentingEnhancer.java
@@ -81,7 +81,6 @@ public class AugmentingEnhancer implements DroneInstanceEnhancer<RemoteWebDriver
      */
     @Override
     public RemoteWebDriver enhance(RemoteWebDriver instance, Class<? extends Annotation> qualifier) {
-        // workaround for https://github.com/SeleniumHQ/selenium/issues/15323
         if (CdpEndpointFinder.getReportedUri(instance.getCapabilities()).isPresent()) {
             return (RemoteWebDriver) augmenter.augment(instance);
         }

--- a/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
+++ b/drone-webdriver/src/test/java/org/jboss/arquillian/drone/webdriver/binary/process/SeleniumServerTestCase.java
@@ -5,17 +5,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.regex.Pattern;
 import org.awaitility.Awaitility;
 import org.jboss.arquillian.test.test.AbstractTestTestBase;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.openqa.selenium.MutableCapabilities;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SeleniumServerTestCase extends AbstractTestTestBase {
     @Rule
@@ -24,18 +20,6 @@ public class SeleniumServerTestCase extends AbstractTestTestBase {
     @Override
     protected void addExtensions(List<Class<?>> extensions) {
         extensions.add(SeleniumServerExecutor.class);
-    }
-
-    @Before
-    public void setup() {
-        LogManager.getLogManager().reset();
-        assertThat(LogManager.getLogManager().getProperty("handlers")).isNull();
-    }
-
-    @After
-    public void tearDown() throws IOException {
-        LogManager.getLogManager().readConfiguration();
-        assertThat(LogManager.getLogManager().getProperty("handlers")).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
Removes workarounds for test suites broken by Selenium since 4.29.0

Once workarounds are no longer necessary, the test suite will pass

Fixes #549

Related issue: https://github.com/SeleniumHQ/selenium/issues/15323